### PR TITLE
Updated to version 2 as first release of SailPoint CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.1.0
+VERSION = 0.2.0
 
 clean:
 	go clean ./...


### PR DESCRIPTION
## Description
What is the intent of this change and why is it being made?

Since the connector CLI was already released at 0.1.2, and this new SailPoint CLI is based on the connector CLI, need to bump the SailPoint CLI to 0.2.0 as the first release.

## How Has This Been Tested?
What testing have you done to verify this change?

Ran the `sail --version` command to verify it is now 0.2.0.
