### PR TITLE
PLTCONN-2270: Fix windows run dev from the initiated project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ mocks:
 	mockgen -source=client/client.go -destination=mocks/client.go -package=mocks
 
 test:
-	docker build -t cli .
-	docker run --rm cli go test -v -count=1 ./...
+	go test -v -count=1 ./...
 
 install:
 	go build -o /usr/local/bin/sail

--- a/cmd/connector/static/package.json
+++ b/cmd/connector/static/package.json
@@ -6,7 +6,7 @@
     "clean": "shx rm -rf ./dist",
     "prebuild": "npm run clean",
     "build": "npx ncc build ./src/index.ts -o ./dist -m -C",
-    "dev": "spcx dist/index.js",
+    "dev": "cross-env NODE_OPTIONS=--enable-source-maps spcx dist/index.js",
     "prettier": "npx prettier --write .",
     "test": "jest --coverage",
     "prepack-zip": "npm ci && npm run build",
@@ -24,7 +24,8 @@
     "prettier": "^2.3.2",
     "shx": "^0.3.3",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.3.5"
+    "typescript": "4.3.5",
+    "cross-env": "7.0.3"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
## Description
 - Pin typescript version
 - Add cross-env to run spcx with environment variable in that terminal process
 - Fix make command to run test with go directly. The docker file is used to release only

## How Has This Been Tested?
Manually tested by initiating project on windows
