### PR TITLE
PLTCONN-1774: Use spcx for packaging connector zip file

### DIFF
--- a/cmd/connector/conn_create.go
+++ b/cmd/connector/conn_create.go
@@ -16,10 +16,8 @@ import (
 
 func newConnCreateCmd(client client.Client) *cobra.Command {
 
-	// TODO: Clean up and not send display name
 	type create struct {
-		DisplayName string `json:"displayName"`
-		Alias       string `json:"alias"`
+		Alias string `json:"alias"`
 	}
 
 	cmd := &cobra.Command{
@@ -34,7 +32,7 @@ func newConnCreateCmd(client client.Client) *cobra.Command {
 				return fmt.Errorf("connector alias cannot be empty")
 			}
 
-			raw, err := json.Marshal(create{DisplayName: alias, Alias: alias})
+			raw, err := json.Marshal(create{Alias: alias})
 			if err != nil {
 				return err
 			}

--- a/cmd/connector/conn_update.go
+++ b/cmd/connector/conn_update.go
@@ -29,8 +29,7 @@ func newConnUpdateCmd(client client.Client) *cobra.Command {
 			}
 
 			u := connectorUpdate{
-				DisplayName: alias,
-				Alias:       alias,
+				Alias: alias,
 			}
 
 			raw, err := json.Marshal(u)

--- a/cmd/connector/models.go
+++ b/cmd/connector/models.go
@@ -7,9 +7,8 @@ import (
 )
 
 type connector struct {
-	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
-	Alias       string `json:"alias"`
+	ID    string `json:"id"`
+	Alias string `json:"alias"`
 }
 
 func (c connector) columns() []string {
@@ -24,8 +23,7 @@ type connectorVersion struct {
 }
 
 type connectorUpdate struct {
-	DisplayName string `json:"displayName"`
-	Alias       string `json:"alias"`
+	Alias string `json:"alias"`
 }
 
 func (v connectorVersion) columns() []string {

--- a/cmd/connector/static/package.json
+++ b/cmd/connector/static/package.json
@@ -6,11 +6,11 @@
     "clean": "shx rm -rf ./dist",
     "prebuild": "npm run clean",
     "build": "npx ncc build ./src/index.ts -o ./dist -m -C",
-    "dev": "cross-env NODE_OPTIONS=--enable-source-maps spcx dist/index.js",
+    "dev": "cross-env NODE_OPTIONS=--enable-source-maps spcx run dist/index.js",
     "prettier": "npx prettier --write .",
     "test": "jest --coverage",
     "prepack-zip": "npm ci && npm run build",
-    "pack-zip": "(cp connector-spec.json ./dist/ && cd ./dist && bestzip $npm_package_name-$npm_package_version.zip ./index.js ./connector-spec.json)"
+    "pack-zip": "spcx package"
   },
   "private": true,
   "dependencies": {
@@ -19,7 +19,6 @@
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@vercel/ncc": "^0.28.6",
-    "bestzip": "^2.2.0",
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
     "shx": "^0.3.3",


### PR DESCRIPTION
## Description
- Use spcx for packaging connector zip file. The bestzip plugin is removed
- Clean up for connector display name: Already switched to Alias months ago.

## How Has This Been Tested?
Manually tested in windows, Mac and linux
