### PR TITLE
Changed goreleaser project name to sail

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-project_name: sailpoint-cli
+project_name: sail
 builds:
   - env: [CGO_ENABLED=0]
     goos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ ADD . /app
 WORKDIR /app
 
 # Copy cli to bin location
-RUN cp sailpoint-cli /usr/local/bin/sail
+RUN cp sail /usr/local/bin/sail

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.2.0"
+var version = "0.2.2"
 
 func NewRootCmd(client client.Client) *cobra.Command {
 	root := &cobra.Command{


### PR DESCRIPTION
## Description

This is a fix for issue #17.

Also, I updated the CLI version to 0.2.2 since the last release tag doesn't follow the same version as the current CLI version.  Once this PR is approved, we can generate a new release with the correct CLI executable name and the correct version.

## How Has This Been Tested?

I installed goreleaser CLI on my Mac and ran the releaser locally.  I confirmed that running goreleaser locally with a project name of `sailpoint-cli` created an executable output in my "dist" folder called `sailpoint-cli`.  I then verified that changing the name to `sail` created the correct executable name in the "dist" folder.

![image](https://user-images.githubusercontent.com/75683148/200664163-b25eaa2a-c38c-48ca-8514-6b89b4a96a1c.png)

