### PR TITLE
PLTCONN-1652 - added buildvcs=false to go build in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ test:
 	go test -v -count=1 ./...
 
 install:
-	go build -o /usr/local/bin/sail
+	go build -o /usr/local/bin/sail -buildvcs=false
 
 .PHONY: clean mocks test install .docker/login .docker/build .docker/push


### PR DESCRIPTION
## Description
What is the intent of this change and why is it being made?
Add -buildvcs flag to go build command to eliminate error "error obtaining VCS status: exit status 128".

## How Has This Been Tested?
What testing have you done to verify this change?
Local "sudo make install"