### PR TITLE
PLTCONN-2686: Fix connector delete cmd

### DIFF
--- a/cmd/connector/conn_delete.go
+++ b/cmd/connector/conn_delete.go
@@ -22,7 +22,7 @@ func newConnDeleteCmd(client client.Client) *cobra.Command {
 			endpoint := cmd.Flags().Lookup("conn-endpoint").Value.String()
 
 			q := map[string]string{"type": "hard-delete"}
-			resp, err := client.Delete(cmd.Context(), util.ResourceUrl(endpoint), q)
+			resp, err := client.Delete(cmd.Context(), util.ResourceUrl(endpoint, connectorRef), q)
 			if err != nil {
 				return err
 			}

--- a/cmd/connector/conn_delete_test.go
+++ b/cmd/connector/conn_delete_test.go
@@ -15,7 +15,7 @@ func TestDeleteConnCmd(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).
+	client.EXPECT().Delete(gomock.Any(), "/beta/platform-connectors/test-connector", gomock.Any()).
 		Return(&http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(bytes.NewReader([]byte("{}")))}, nil).
 		Times(1)
 


### PR DESCRIPTION
## Description

Need to include connector id in the url path when deleting.

## How Has This Been Tested?

Updated unit test. Tested locally.
