### PR TITLE
PLTCONN-2707: Support both new and deprecated format for command invocation

### DIFF
--- a/cmd/connector/client/util.go
+++ b/cmd/connector/client/util.go
@@ -4,6 +4,7 @@ package connclient
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -18,8 +19,22 @@ type RawResponse struct {
 	Data json.RawMessage `json:"data"`
 }
 
-// parseResponse parses responses into the new format if the given response is in deprecated format
-func parseResponse(resp []byte) (rawResps []RawResponse, state *RawResponse, err error) {
+// parseResponse parses a single response into the new format if the given response is in deprecated format
+func parseResponse(resp []byte) (rawResp *RawResponse, err error) {
+	rawResps, _, err := parseResponseList(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rawResps) != 1 {
+		return nil, fmt.Errorf("failed to parse response")
+	}
+
+	return &rawResps[0], nil
+}
+
+// parseResponseList parses responses into the new format if the given response is in deprecated format
+func parseResponseList(resp []byte) (rawResps []RawResponse, state *RawResponse, err error) {
 	decoder := json.NewDecoder(bytes.NewReader(resp))
 	deprecatedFormat := false
 	for {

--- a/cmd/connector/client/util.go
+++ b/cmd/connector/client/util.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+const (
+	ResponseTypeOutput = "output"
+	ResponseTypeState  = "state"
+)
+
+// RawResponse represents the response format from the connector
+type RawResponse struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// parseResponse parses responses into the new format if the given response is in deprecated format
+func parseResponse(resp []byte) (rawResps []RawResponse, state *RawResponse, err error) {
+	decoder := json.NewDecoder(bytes.NewReader(resp))
+	deprecatedFormat := false
+	for {
+		rr := &RawResponse{}
+		err = decoder.Decode(rr)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+				break
+			}
+			return nil, nil, err
+		}
+
+		if rr.Type == "" || rr.Data == nil {
+			deprecatedFormat = true
+			break
+		}
+
+		if rr.Type == ResponseTypeOutput {
+			rawResps = append(rawResps, *rr)
+
+		}
+
+		if rr.Type == ResponseTypeState {
+			state = rr
+		}
+	}
+
+	if deprecatedFormat {
+		decoder := json.NewDecoder(bytes.NewReader(resp))
+		for {
+			rr := json.RawMessage{}
+			err = decoder.Decode(&rr)
+			if err != nil {
+				if err == io.EOF {
+					err = nil
+					break
+				}
+				return nil, nil, err
+			}
+
+			rawResps = append(rawResps, RawResponse{
+				Type: ResponseTypeOutput,
+				Data: rr,
+			})
+
+		}
+	}
+
+	return rawResps, state, err
+}

--- a/cmd/connector/client/util_test.go
+++ b/cmd/connector/client/util_test.go
@@ -10,7 +10,7 @@ const rawAccount = `{"identity":"john.doe","uuid":"1","attributes":{"email":"joh
 
 func TestParseDeprecatedAccountFormat(t *testing.T) {
 	response := []byte(rawAccount)
-	rawResps, state, err := parseResponse(response)
+	rawResps, state, err := parseResponseList(response)
 	if err != nil {
 		t.Errorf("failed to parse account in deprecated format: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestParseDeprecatedAccountFormat(t *testing.T) {
 
 func TestParseNewAccountFormat(t *testing.T) {
 	response := []byte(fmt.Sprintf(`{"type": "output", "data": %s}`, rawAccount))
-	rawResps, state, err := parseResponse(response)
+	rawResps, state, err := parseResponseList(response)
 	if err != nil {
 		t.Errorf("failed to parse account in deprecated format: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestParseNewAccountFormatWithState(t *testing.T) {
 	stateStr := `{"foo": "bar"}`
 	response := []byte(fmt.Sprintf(`{"type": "output", "data": %s}{"type": "state", "data": %s}`, rawAccount, stateStr))
 	// accounts, state, printableResp, err := responseToAccounts(response)
-	rawResps, state, err := parseResponse(response)
+	rawResps, state, err := parseResponseList(response)
 	if err != nil {
 		t.Errorf("failed to parse account in deprecated format: %v", err)
 	}

--- a/cmd/connector/client/util_test.go
+++ b/cmd/connector/client/util_test.go
@@ -8,7 +8,7 @@ import (
 
 const rawAccount = `{"identity":"john.doe","uuid":"1","attributes":{"email":"john.doe@example.com","firstName":"john","lastName":"doe"}}`
 
-func TestParseDeprecatedAccountFormat(t *testing.T) {
+func TestParseDeprecatedAccountListFormat(t *testing.T) {
 	response := []byte(rawAccount)
 	rawResps, state, err := parseResponseList(response)
 	if err != nil {
@@ -24,7 +24,7 @@ func TestParseDeprecatedAccountFormat(t *testing.T) {
 	}
 }
 
-func TestParseNewAccountFormat(t *testing.T) {
+func TestParseNewAccountListFormat(t *testing.T) {
 	response := []byte(fmt.Sprintf(`{"type": "output", "data": %s}`, rawAccount))
 	rawResps, state, err := parseResponseList(response)
 	if err != nil {
@@ -40,7 +40,7 @@ func TestParseNewAccountFormat(t *testing.T) {
 	}
 }
 
-func TestParseNewAccountFormatWithState(t *testing.T) {
+func TestParseNewAccountListFormatWithState(t *testing.T) {
 	stateStr := `{"foo": "bar"}`
 	response := []byte(fmt.Sprintf(`{"type": "output", "data": %s}{"type": "state", "data": %s}`, rawAccount, stateStr))
 	// accounts, state, printableResp, err := responseToAccounts(response)
@@ -59,5 +59,29 @@ func TestParseNewAccountFormatWithState(t *testing.T) {
 
 	if string(state.Data[:]) != stateStr {
 		t.Errorf("state is not in correct format. expecting %s, got %s", stateStr, string(state.Data[:]))
+	}
+}
+
+func TestParseDepracatedAccountFormat(t *testing.T) {
+	response := []byte(rawAccount)
+	rawResp, err := parseResponse(response)
+	if err != nil {
+		t.Errorf("failed to parse account in deprecated format: %v", err)
+	}
+
+	if string(rawResp.Data[:]) != rawAccount {
+		t.Errorf("state is not in correct format. expecting %s, got %s", rawAccount, string(rawResp.Data[:]))
+	}
+}
+
+func TestParseNewAccountFormat(t *testing.T) {
+	response := []byte(fmt.Sprintf(`{"type": "output", "data": %s}`, rawAccount))
+	rawResp, err := parseResponse(response)
+	if err != nil {
+		t.Errorf("failed to parse account in deprecated format: %v", err)
+	}
+
+	if string(rawResp.Data[:]) != rawAccount {
+		t.Errorf("state is not in correct format. expecting %s, got %s", rawAccount, string(rawResp.Data[:]))
 	}
 }

--- a/cmd/connector/client/util_test.go
+++ b/cmd/connector/client/util_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connclient
+
+import (
+	"fmt"
+	"testing"
+)
+
+const rawAccount = `{"identity":"john.doe","uuid":"1","attributes":{"email":"john.doe@example.com","firstName":"john","lastName":"doe"}}`
+
+func TestParseDeprecatedAccountFormat(t *testing.T) {
+	response := []byte(rawAccount)
+	rawResps, state, err := parseResponse(response)
+	if err != nil {
+		t.Errorf("failed to parse account in deprecated format: %v", err)
+	}
+
+	if len(rawResps) != 1 {
+		t.Errorf("deprecated account parsing error. expecting %d account, got %d ", 1, len(rawResps))
+	}
+
+	if state != nil {
+		t.Errorf("does not expect state from deprecated account format, got %s", string(state.Data[:]))
+	}
+}
+
+func TestParseNewAccountFormat(t *testing.T) {
+	response := []byte(fmt.Sprintf(`{"type": "output", "data": %s}`, rawAccount))
+	rawResps, state, err := parseResponse(response)
+	if err != nil {
+		t.Errorf("failed to parse account in deprecated format: %v", err)
+	}
+
+	if len(rawResps) != 1 {
+		t.Errorf("deprecated account parsing error. expecting %d account, got %d ", 1, len(rawResps))
+	}
+
+	if state != nil {
+		t.Errorf("does not expect state from deprecated account format, got %s", string(state.Data[:]))
+	}
+}
+
+func TestParseNewAccountFormatWithState(t *testing.T) {
+	stateStr := `{"foo": "bar"}`
+	response := []byte(fmt.Sprintf(`{"type": "output", "data": %s}{"type": "state", "data": %s}`, rawAccount, stateStr))
+	// accounts, state, printableResp, err := responseToAccounts(response)
+	rawResps, state, err := parseResponse(response)
+	if err != nil {
+		t.Errorf("failed to parse account in deprecated format: %v", err)
+	}
+
+	if len(rawResps) != 1 {
+		t.Errorf("deprecated account parsing error. expecting %d account, got %d ", 1, len(rawResps))
+	}
+
+	if state == nil {
+		t.Errorf("failed to read state")
+	}
+
+	if string(state.Data[:]) != stateStr {
+		t.Errorf("state is not in correct format. expecting %s, got %s", stateStr, string(state.Data[:]))
+	}
+}

--- a/cmd/connector/conn_invoke_account_list.go
+++ b/cmd/connector/conn_invoke_account_list.go
@@ -19,12 +19,18 @@ func newConnInvokeAccountListCmd(client client.Client) *cobra.Command {
 				return err
 			}
 
-			_, rawResponse, err := cc.AccountList(ctx)
+			_, state, printable, err := cc.AccountList(ctx)
 			if err != nil {
 				return err
 			}
 
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(rawResponse))
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Accounts:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(printable))
+
+			if state != nil {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nState:\n")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(state))
+			}
 			return nil
 		},
 	}

--- a/cmd/connector/conn_invoke_entitlement_list.go
+++ b/cmd/connector/conn_invoke_entitlement_list.go
@@ -21,12 +21,18 @@ func newConnInvokeEntitlementListCmd(client client.Client) *cobra.Command {
 			}
 
 			t := cmd.Flags().Lookup("type").Value.String()
-			_, rawResponse, err := cc.EntitlementList(ctx, t)
+			_, state, printable, err := cc.EntitlementList(ctx, t)
 			if err != nil {
 				return err
 			}
 
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(rawResponse))
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Entitlements:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(printable))
+
+			if state != nil {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nState:\n")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(state))
+			}
 
 			return nil
 		},

--- a/cmd/connector/validate/account_create.go
+++ b/cmd/connector/validate/account_create.go
@@ -125,7 +125,7 @@ var accountCreateChecks = []Check{
 			"std:account:list",
 		},
 		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
-			accountsPreCreate, _, err := cc.AccountList(ctx)
+			accountsPreCreate, _, _, err := cc.AccountList(ctx)
 			if err != nil {
 				res.err(err)
 				return
@@ -146,7 +146,7 @@ var accountCreateChecks = []Check{
 				return
 			}
 
-			accountsPostCreate, _, err := cc.AccountList(ctx)
+			accountsPostCreate, _, _, err := cc.AccountList(ctx)
 			if err != nil {
 				res.err(err)
 				return
@@ -178,7 +178,7 @@ var accountCreateChecks = []Check{
 				res.errf("was able to read deleted account: %q", acct.Identity)
 			}
 
-			accountsPostDelete, _, err := cc.AccountList(ctx)
+			accountsPostDelete, _, _, err := cc.AccountList(ctx)
 			if err != nil {
 				res.err(err)
 			}

--- a/cmd/connector/validate/account_read.go
+++ b/cmd/connector/validate/account_read.go
@@ -19,7 +19,7 @@ var accountReadChecks = []Check{
 			"std:account:list",
 		},
 		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
-			accounts, _, err := cc.AccountList(ctx)
+			accounts, _, _, err := cc.AccountList(ctx)
 			if err != nil {
 				res.err(err)
 				return
@@ -77,7 +77,7 @@ var accountReadChecks = []Check{
 				attrsByName[value.Name] = value
 			}
 
-			accounts, _, err := cc.AccountList(ctx)
+			accounts, _, _, err := cc.AccountList(ctx)
 			if err != nil {
 				res.err(err)
 				return

--- a/cmd/connector/validate/account_update.go
+++ b/cmd/connector/validate/account_update.go
@@ -18,7 +18,7 @@ var accountUpdateChecks = []Check{
 			"std:account:update",
 		},
 		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
-			accounts, _, err := cc.AccountList(ctx)
+			accounts, _, _, err := cc.AccountList(ctx)
 			if err != nil {
 				res.err(err)
 			}

--- a/cmd/connector/validate/account_update.go
+++ b/cmd/connector/validate/account_update.go
@@ -79,7 +79,7 @@ var accountUpdateChecks = []Check{
 				return
 			}
 
-			entitlements, _, err := cc.EntitlementList(ctx, "group")
+			entitlements, _, _, err := cc.EntitlementList(ctx, "group")
 			if err != nil {
 				res.err(err)
 				return

--- a/cmd/connector/validate/entitlement_read.go
+++ b/cmd/connector/validate/entitlement_read.go
@@ -32,7 +32,7 @@ var entitlementReadChecks = []Check{
 			"std:entitlement:list",
 		},
 		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
-			entitlements, _, err := cc.EntitlementList(ctx, "group")
+			entitlements, _, _, err := cc.EntitlementList(ctx, "group")
 			if err != nil {
 				res.err(err)
 				return
@@ -77,7 +77,7 @@ var entitlementReadChecks = []Check{
 				attrsByName[value.Name] = value
 			}
 
-			entitlements, _, err := cc.EntitlementList(ctx, "group")
+			entitlements, _, _, err := cc.EntitlementList(ctx, "group")
 			if err != nil {
 				res.err(err)
 				return


### PR DESCRIPTION
## Description
Support both new and deprecated format for command invocation

## How Has This Been Tested?
Manual testing with new response turned on and off. Added unit tests for the utile methods.

<img width="1704" alt="Screenshot 2023-02-14 at 12 57 40 PM" src="https://user-images.githubusercontent.com/42616890/219089387-558d91c2-9e31-46d3-ae6c-ab65703c841e.png">
<img width="1714" alt="Screenshot 2023-02-14 at 12 59 15 PM" src="https://user-images.githubusercontent.com/42616890/219089429-6f071676-d95e-41eb-93e8-b7bd7326febd.png">
<img width="1726" alt="Screenshot 2023-02-14 at 12 59 55 PM" src="https://user-images.githubusercontent.com/42616890/219089440-850dd48a-f54e-49c6-a396-0dd955ac601a.png">

