### PR TITLE
PLTCONN-2777 Update package.json to use connector-sdk from npm version instead of git

### DIFF
--- a/cmd/connector/static/package.json
+++ b/cmd/connector/static/package.json
@@ -14,7 +14,7 @@
   },
   "private": true,
   "dependencies": {
-    "@sailpoint/connector-sdk": "github:sailpoint-oss/sp-connector-sdk-js#main"
+    "@sailpoint/connector-sdk": "^1.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",


### PR DESCRIPTION
## Description
What is the intent of this change and why is it being made? Update to use connector-sdk from npm

## How Has This Been Tested?
What testing have you done to verify this change? Local testing
