### PR TITLE
Github example for base64 certs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Obtain signing cert
         run: |
           cert="$(mktemp -t cert.XXX)"
-          base64 -d <<<"$CERT_CONTENTS" > "$cert"
+          echo $CERT_CONTENTS | base64 --decode > "$cert"
           echo "CERT_FILE=$cert" >> $GITHUB_ENV
         env:
           CERT_CONTENTS: ${{ secrets.OSS_SIGNING_CERT }}


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/encrypted-secrets#storing-base64-binary-blobs-as-secrets

## Description
What is the intent of this change and why is it being made?

## How Has This Been Tested?
What testing have you done to verify this change?
