### PR TITLE
removed cross-env and added sourcemap to tsconfig

### DIFF
--- a/cmd/connector/static/package.json
+++ b/cmd/connector/static/package.json
@@ -6,7 +6,7 @@
     "clean": "shx rm -rf ./dist",
     "prebuild": "npm run clean",
     "build": "npx ncc build ./src/index.ts -o ./dist -m -C",
-    "dev": "cross-env NODE_OPTIONS=--enable-source-maps spcx run dist/index.js",
+    "dev": "spcx run dist/index.js",
     "prettier": "npx prettier --write .",
     "test": "jest --coverage",
     "prepack-zip": "npm ci && npm run build",
@@ -23,8 +23,7 @@
     "prettier": "^2.3.2",
     "shx": "^0.3.3",
     "ts-jest": "^27.0.5",
-    "typescript": "4.3.5",
-    "cross-env": "7.0.3"
+    "typescript": "4.3.5"
   },
   "jest": {
     "preset": "ts-jest",

--- a/cmd/connector/static/package.json
+++ b/cmd/connector/static/package.json
@@ -6,7 +6,8 @@
     "clean": "shx rm -rf ./dist",
     "prebuild": "npm run clean",
     "build": "npx ncc build ./src/index.ts -o ./dist -m -C",
-    "dev": "spcx run dist/index.js",
+    "dev": "cross-env NODE_OPTIONS=--enable-source-maps spcx run dist/index.js",
+    "debug": "spcx run dist/index.js",
     "prettier": "npx prettier --write .",
     "test": "jest --coverage",
     "prepack-zip": "npm ci && npm run build",
@@ -23,7 +24,8 @@
     "prettier": "^2.3.2",
     "shx": "^0.3.3",
     "ts-jest": "^27.0.5",
-    "typescript": "4.3.5"
+    "typescript": "4.3.5",
+    "cross-env": "7.0.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/cmd/connector/static/tsconfig.json
+++ b/cmd/connector/static/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "sourceMap": true,
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Description
adding sourcemap to the typescript config file removes the need to include it in the dev command, which allows for remote debugging right away and still allows for cross platform compatibility. the output in the dist folder is unaffected 

## How Has This Been Tested?
Ran in both windows powershell, cmd as well as ubuntu. I have not run in macos, but as far as I know, the cross env was never required for macos. 
