### PR TITLE
PLTCONN-3577: Commands to manage connector customizers Part 1

### DIFF
--- a/cmd/connector/conn.go
+++ b/cmd/connector/conn.go
@@ -56,6 +56,7 @@ func NewConnCmd(term terminal.Terminal) *cobra.Command {
 		newConnStatsCmd(Client),
 		newConnDeleteCmd(Client),
 		newConnCustomizersCmd(Client),
+		newConnInstancesCmd(Client),
 	)
 
 	return conn

--- a/cmd/connector/conn.go
+++ b/cmd/connector/conn.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	connectorsEndpoint = "/beta/platform-connectors"
+	connectorsEndpoint           = "/beta/platform-connectors"
+	connectorInstancesEndpoint   = "/beta/connector-instances"
+	connectorCustomizersEndpoint = "/beta/connector-customizers"
 )
 
 func NewConnCmd(term terminal.Terminal) *cobra.Command {
@@ -53,6 +55,7 @@ func NewConnCmd(term terminal.Terminal) *cobra.Command {
 		newConnLogsCmd(Client),
 		newConnStatsCmd(Client),
 		newConnDeleteCmd(Client),
+		newConnCustomizersCmd(Client),
 	)
 
 	return conn

--- a/cmd/connector/conn_invoke_change_password_test.go
+++ b/cmd/connector/conn_invoke_change_password_test.go
@@ -16,7 +16,7 @@ func TestChangePasswordWithoutInput(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := mocks.NewMockClient(ctrl)
-	term := mocks.NewMockTerm(ctrl)
+	term := mocks.NewMockTerminal(ctrl)
 
 	cmd := newConnInvokeChangePasswordCmd(client, term)
 	addRequiredFlagsFromParentCmd(cmd)
@@ -43,7 +43,7 @@ func TestChangePasswordWithIdentityAndPassword(t *testing.T) {
 		Post(gomock.Any(), gomock.Any(), "application/json", bytes.NewReader([]byte(i))).
 		Return(&http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("{}")))}, nil)
 
-	term := mocks.NewMockTerm(ctrl)
+	term := mocks.NewMockTerminal(ctrl)
 	term.EXPECT().
 		PromptPassword(gomock.Any()).
 		Return("password", nil)
@@ -73,7 +73,7 @@ func TestChangePasswordWithIdentityAndPasswordAndUniqueId(t *testing.T) {
 		Post(gomock.Any(), gomock.Any(), "application/json", bytes.NewReader([]byte(i))).
 		Return(&http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("{}")))}, nil)
 
-	term := mocks.NewMockTerm(ctrl)
+	term := mocks.NewMockTerminal(ctrl)
 	term.EXPECT().
 		PromptPassword(gomock.Any()).
 		Return("password", nil)

--- a/cmd/connector/conn_invoke_test.go
+++ b/cmd/connector/conn_invoke_test.go
@@ -24,7 +24,7 @@ func TestNewConnInvokeCmd_noArgs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	cmd := newConnInvokeCmd(mocks.NewMockClient(ctrl), mocks.NewMockTerm(ctrl))
+	cmd := newConnInvokeCmd(mocks.NewMockClient(ctrl), mocks.NewMockTerminal(ctrl))
 	if len(cmd.Commands()) != numConnInvokeSubcommands {
 		t.Fatalf("expected: %d, actual: %d", len(cmd.Commands()), numConnInvokeSubcommands)
 	}

--- a/cmd/connector/conn_test.go
+++ b/cmd/connector/conn_test.go
@@ -15,7 +15,7 @@ import (
 // Unit tests for conn.go
 
 // Expected number of subcommands to `connectors`
-const numConnSubcommands = 14
+const numConnSubcommands = 16
 
 func TestConnResourceUrl(t *testing.T) {
 	testEndpoint := "http://localhost:7100/resources"

--- a/cmd/connector/conn_test.go
+++ b/cmd/connector/conn_test.go
@@ -33,7 +33,7 @@ func TestNewConnCmd_noArgs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	cmd := NewConnCmd(mocks.NewMockTerm(ctrl))
+	cmd := NewConnCmd(mocks.NewMockTerminal(ctrl))
 	if len(cmd.Commands()) != numConnSubcommands {
 		t.Fatalf("expected: %d, actual: %d", len(cmd.Commands()), numConnSubcommands)
 	}

--- a/cmd/connector/customizer.go
+++ b/cmd/connector/customizer.go
@@ -18,9 +18,11 @@ func newConnCustomizersCmd(client client.Client) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newCustomizerCreateCmd(client),
 		newCustomizerListCmd(client),
+		newCustomizerCreateCmd(client),
+		newCustomizerGetCmd(client),
 		newCustomizerUpdateCmd(client),
+		newCustomizerDeleteCmd(client),
 	)
 
 	return cmd

--- a/cmd/connector/customizer.go
+++ b/cmd/connector/customizer.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"fmt"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func newConnCustomizersCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "customizers",
+		Short: "Manage connector customizers",
+		Run: func(cmd *cobra.Command, args []string) {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), cmd.UsageString())
+		},
+	}
+
+	cmd.AddCommand(
+		newCustomizerCreateCmd(client),
+	)
+
+	return cmd
+}

--- a/cmd/connector/customizer.go
+++ b/cmd/connector/customizer.go
@@ -24,6 +24,8 @@ func newConnCustomizersCmd(client client.Client) *cobra.Command {
 		newCustomizerUpdateCmd(client),
 		newCustomizerDeleteCmd(client),
 		newCustomizerCreateVersionCmd(client),
+		newCustomizerLinkCmd(client),
+		newCustomizerUnlinkCmd(client),
 	)
 
 	return cmd

--- a/cmd/connector/customizer.go
+++ b/cmd/connector/customizer.go
@@ -23,6 +23,7 @@ func newConnCustomizersCmd(client client.Client) *cobra.Command {
 		newCustomizerGetCmd(client),
 		newCustomizerUpdateCmd(client),
 		newCustomizerDeleteCmd(client),
+		newCustomizerCreateVersionCmd(client),
 	)
 
 	return cmd

--- a/cmd/connector/customizer.go
+++ b/cmd/connector/customizer.go
@@ -19,6 +19,8 @@ func newConnCustomizersCmd(client client.Client) *cobra.Command {
 
 	cmd.AddCommand(
 		newCustomizerCreateCmd(client),
+		newCustomizerListCmd(client),
+		newCustomizerUpdateCmd(client),
 	)
 
 	return cmd

--- a/cmd/connector/customizer_create.go
+++ b/cmd/connector/customizer_create.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func newCustomizerCreateCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create <customizer-name>",
+		Short:   "Create Connector Customizer",
+		Example: "sail conn customizers create \"My Customizer\"",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			raw, err := json.Marshal(customizer{Name: args[0]})
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Post(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint), "application/json", bytes.NewReader(raw))
+			if err != nil {
+				return err
+			}
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(resp.Body)
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("create customizer failed. status: %s\nbody: %s", resp.Status, string(body))
+			}
+
+			var cus customizer
+			err = json.NewDecoder(resp.Body).Decode(&cus)
+			if err != nil {
+				return err
+			}
+
+			table := tablewriter.NewWriter(cmd.OutOrStdout())
+			table.SetHeader(customizerColumns)
+			table.Append(cus.columns())
+			table.Render()
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/connector/customizer_create_version.go
+++ b/cmd/connector/customizer_create_version.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func newCustomizerCreateVersionCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "upload",
+		Short:   "Upload connector customizer",
+		Example: "sail conn customizers upload -c 1234 -f path/to/zip/archive.zip",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := cmd.Flags().Lookup("id").Value.String()
+			archivePath := cmd.Flags().Lookup("file").Value.String()
+
+			f, err := os.Open(archivePath)
+			if err != nil {
+				return err
+			}
+
+			info, err := f.Stat()
+			if err != nil {
+				return err
+			}
+
+			_, err = zip.NewReader(f, info.Size())
+			if err != nil {
+				return err
+			}
+
+			_, err = f.Seek(0, io.SeekStart)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Post(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint, id, "versions"), "application/zip", f)
+			if err != nil {
+				return err
+			}
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(resp.Body)
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("upload customizer failed. status: %s\nbody: %s", resp.Status, string(body))
+			}
+
+			var cv customizerVersion
+			err = json.NewDecoder(resp.Body).Decode(&cv)
+			if err != nil {
+				return err
+			}
+
+			table := tablewriter.NewWriter(cmd.OutOrStdout())
+			table.SetHeader(customizerVersionColumns)
+			table.Append(cv.columns())
+			table.Render()
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("id", "c", "", "Connector customizer ID")
+	_ = cmd.MarkFlagRequired("id")
+
+	cmd.Flags().StringP("file", "f", "", "ZIP Archive")
+	_ = cmd.MarkFlagRequired("file")
+
+	return cmd
+}

--- a/cmd/connector/customizer_delete.go
+++ b/cmd/connector/customizer_delete.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func newCustomizerDeleteCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Short:   "Delete connector customizer",
+		Example: "sail conn customizers delete -c 1234",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := cmd.Flags().Lookup("id").Value.String()
+
+			q := map[string]string{"type": "hard-delete"}
+			resp, err := client.Delete(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint, id), q)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			if resp.StatusCode != http.StatusNoContent {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("delete customizer failed. status: %s\nbody: %s", resp.Status, string(body))
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "connector customizer %s deleted.\n", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("id", "c", "", "Connector ID or Alias")
+	_ = cmd.MarkFlagRequired("id")
+
+	return cmd
+}

--- a/cmd/connector/customizer_delete.go
+++ b/cmd/connector/customizer_delete.go
@@ -39,7 +39,7 @@ func newCustomizerDeleteCmd(client client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("id", "c", "", "Connector ID or Alias")
+	cmd.Flags().StringP("id", "c", "", "Connector customizer ID")
 	_ = cmd.MarkFlagRequired("id")
 
 	return cmd

--- a/cmd/connector/customizer_get.go
+++ b/cmd/connector/customizer_get.go
@@ -50,7 +50,7 @@ func newCustomizerGetCmd(client client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("id", "c", "", "Connector ID or Alias")
+	cmd.Flags().StringP("id", "c", "", "Connector customizer ID")
 	_ = cmd.MarkFlagRequired("id")
 
 	return cmd

--- a/cmd/connector/customizer_get.go
+++ b/cmd/connector/customizer_get.go
@@ -2,7 +2,6 @@
 package connector
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,23 +13,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCustomizerUpdateCmd(client client.Client) *cobra.Command {
+func newCustomizerGetCmd(client client.Client) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "update",
-		Short:   "Create connector customizer",
-		Example: "sail conn customizers update -c 1234 -n \"My Customizer\"",
+		Use:     "get",
+		Short:   "Get connector customizer",
+		Example: "sail conn customizers update -c 1234",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			id := cmd.Flags().Lookup("id").Value.String()
-			name := cmd.Flags().Lookup("name").Value.String()
 
-			raw, err := json.Marshal(customizer{Name: name})
-			if err != nil {
-				return err
-			}
-
-			resp, err := client.Put(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint, id), "application/json", bytes.NewReader(raw))
+			resp, err := client.Get(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint, id))
 			if err != nil {
 				return err
 			}
@@ -58,11 +50,8 @@ func newCustomizerUpdateCmd(client client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("id", "c", "", "Specify connector customizer id")
+	cmd.Flags().StringP("id", "c", "", "Connector ID or Alias")
 	_ = cmd.MarkFlagRequired("id")
-
-	cmd.Flags().StringP("name", "n", "", "name of the connector customizer")
-	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
 }

--- a/cmd/connector/customizer_link.go
+++ b/cmd/connector/customizer_link.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func newCustomizerLinkCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "link",
+		Short:   "Link connector customizer to connector instance",
+		Example: "sail conn customizers link -c 1234 -i 5678",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			customizerID := cmd.Flags().Lookup("id").Value.String()
+			instanceID := cmd.Flags().Lookup("instance-id").Value.String()
+
+			raw, err := json.Marshal([]interface{}{map[string]interface{}{
+				"op":    "replace",
+				"path":  "/connectorCustomizerId",
+				"value": customizerID,
+			}})
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Patch(cmd.Context(), util.ResourceUrl(connectorInstancesEndpoint, instanceID), bytes.NewReader(raw))
+			if err != nil {
+				return err
+			}
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(resp.Body)
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("link customizer failed. status: %s\nbody: %s", resp.Status, string(body))
+			}
+
+			var i instance
+			err = json.NewDecoder(resp.Body).Decode(&i)
+			if err != nil {
+				return err
+			}
+
+			table := tablewriter.NewWriter(cmd.OutOrStdout())
+			table.SetHeader(instanceColumns)
+			table.Append(i.columns())
+			table.Render()
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("id", "c", "", "Connector customizer ID")
+	_ = cmd.MarkFlagRequired("customizer-id")
+
+	cmd.Flags().StringP("instance-id", "i", "", "Connector instance ID")
+	_ = cmd.MarkFlagRequired("instance-id")
+
+	return cmd
+}

--- a/cmd/connector/customizer_list.go
+++ b/cmd/connector/customizer_list.go
@@ -39,17 +39,6 @@ func newCustomizerListCmd(client client.Client) *cobra.Command {
 				return err
 			}
 
-			// raw, err := io.ReadAll(resp.Body)
-			// if err != nil {
-			// 	return err
-			// }
-
-			// var tags []tag
-			// err = json.Unmarshal(raw, &tags)
-			// if err != nil {
-			// 	return err
-			// }
-
 			table := tablewriter.NewWriter(cmd.OutOrStdout())
 			table.SetHeader(customizerColumns)
 			for _, c := range customizers {

--- a/cmd/connector/customizer_list.go
+++ b/cmd/connector/customizer_list.go
@@ -18,6 +18,7 @@ func newCustomizerListCmd(client client.Client) *cobra.Command {
 		Use:     "list",
 		Short:   "List all customizers",
 		Example: "sail conn customizers list",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			resp, err := client.Get(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint))

--- a/cmd/connector/customizer_list.go
+++ b/cmd/connector/customizer_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, SailPoint Technologies, Inc. All rights reserved.
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
 package connector
 
 import (

--- a/cmd/connector/customizer_list.go
+++ b/cmd/connector/customizer_list.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func newCustomizerListCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List all customizers",
+		Example: "sail conn customizers list",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			resp, err := client.Get(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint))
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("list customizers failed. status: %s\nbody: %s", resp.Status, string(body))
+			}
+
+			var customizers []customizer
+			err = json.NewDecoder(resp.Body).Decode(&customizers)
+			if err != nil {
+				return err
+			}
+
+			// raw, err := io.ReadAll(resp.Body)
+			// if err != nil {
+			// 	return err
+			// }
+
+			// var tags []tag
+			// err = json.Unmarshal(raw, &tags)
+			// if err != nil {
+			// 	return err
+			// }
+
+			table := tablewriter.NewWriter(cmd.OutOrStdout())
+			table.SetHeader(customizerColumns)
+			for _, c := range customizers {
+				table.Append(c.columns())
+			}
+			table.Render()
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/connector/customizer_unlink.go
+++ b/cmd/connector/customizer_unlink.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func newCustomizerUnlinkCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "unlink",
+		Short:   "Unlink connector customizer from connector instance",
+		Example: "sail conn customizers unlink -i 5678",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			instanceID := cmd.Flags().Lookup("instance-id").Value.String()
+
+			raw, err := json.Marshal([]interface{}{map[string]interface{}{
+				"op":   "remove",
+				"path": "/connectorCustomizerId",
+			}})
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Patch(cmd.Context(), util.ResourceUrl(connectorInstancesEndpoint, instanceID), bytes.NewReader(raw))
+			if err != nil {
+				return err
+			}
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(resp.Body)
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("link customizer failed. status: %s\nbody: %s", resp.Status, string(body))
+			}
+
+			var i instance
+			err = json.NewDecoder(resp.Body).Decode(&i)
+			if err != nil {
+				return err
+			}
+
+			table := tablewriter.NewWriter(cmd.OutOrStdout())
+			table.SetHeader(instanceColumns)
+			table.Append(i.columns())
+			table.Render()
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("instance-id", "i", "", "Connector instance ID")
+	_ = cmd.MarkFlagRequired("instance-id")
+
+	return cmd
+}

--- a/cmd/connector/customizer_unlink.go
+++ b/cmd/connector/customizer_unlink.go
@@ -41,7 +41,7 @@ func newCustomizerUnlinkCmd(client client.Client) *cobra.Command {
 
 			if resp.StatusCode != http.StatusOK {
 				body, _ := io.ReadAll(resp.Body)
-				return fmt.Errorf("link customizer failed. status: %s\nbody: %s", resp.Status, string(body))
+				return fmt.Errorf("unlink customizer failed. status: %s\nbody: %s", resp.Status, string(body))
 			}
 
 			var i instance

--- a/cmd/connector/customizer_update.go
+++ b/cmd/connector/customizer_update.go
@@ -58,7 +58,7 @@ func newCustomizerUpdateCmd(client client.Client) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("id", "c", "", "Specify connector customizer id")
+	cmd.Flags().StringP("id", "c", "", "Connector customizer ID")
 	_ = cmd.MarkFlagRequired("id")
 
 	cmd.Flags().StringP("name", "n", "", "name of the connector customizer")

--- a/cmd/connector/customizer_update.go
+++ b/cmd/connector/customizer_update.go
@@ -14,19 +14,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCustomizerCreateCmd(client client.Client) *cobra.Command {
+func newCustomizerUpdateCmd(client client.Client) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create <customizer-name>",
-		Short:   "Create connector customizer",
-		Example: "sail conn customizers create \"My Customizer\"",
-		Args:    cobra.ExactArgs(1),
+		Use:   "update",
+		Short: "Create connector customizer",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			raw, err := json.Marshal(customizer{Name: args[0]})
+
+			id := cmd.Flags().Lookup("id").Value.String()
+			name := cmd.Flags().Lookup("name").Value.String()
+
+			raw, err := json.Marshal(customizer{Name: name})
 			if err != nil {
 				return err
 			}
 
-			resp, err := client.Post(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint), "application/json", bytes.NewReader(raw))
+			resp, err := client.Put(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint, id), "application/json", bytes.NewReader(raw))
 			if err != nil {
 				return err
 			}
@@ -53,6 +56,12 @@ func newCustomizerCreateCmd(client client.Client) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringP("id", "c", "", "Specify connector customizer id")
+	_ = cmd.MarkFlagRequired("id")
+
+	cmd.Flags().StringP("name", "n", "", "name of the connector customizer")
+	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
 }

--- a/cmd/connector/instance.go
+++ b/cmd/connector/instance.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"fmt"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func newConnInstancesCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "instances",
+		Short: "Manage connector instances",
+		Run: func(cmd *cobra.Command, args []string) {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), cmd.UsageString())
+		},
+	}
+
+	cmd.AddCommand(
+		newInstanceListCmd(client),
+	)
+
+	return cmd
+}

--- a/cmd/connector/instance_list.go
+++ b/cmd/connector/instance_list.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func newInstanceListCmd(client client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List all connector instances",
+		Example: "sail conn instances list",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			resp, err := client.Get(cmd.Context(), util.ResourceUrl(connectorInstancesEndpoint))
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("list connector instances failed. status: %s\nbody: %s", resp.Status, string(body))
+			}
+
+			var instances []instance
+			err = json.NewDecoder(resp.Body).Decode(&instances)
+			if err != nil {
+				return err
+			}
+
+			table := tablewriter.NewWriter(cmd.OutOrStdout())
+			table.SetHeader(instanceColumns)
+			for _, c := range instances {
+				table.Append(c.columns())
+			}
+			table.Render()
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/connector/models.go
+++ b/cmd/connector/models.go
@@ -53,3 +53,14 @@ type TagCreate struct {
 type TagUpdate struct {
 	ActiveVersion uint32 `json:"activeVersion"`
 }
+
+type customizer struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (c customizer) columns() []string {
+	return []string{c.ID, c.Name}
+}
+
+var customizerColumns = []string{"ID", "Name"}

--- a/cmd/connector/models.go
+++ b/cmd/connector/models.go
@@ -55,12 +55,16 @@ type TagUpdate struct {
 }
 
 type customizer struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	ImageVersion *int   `json:"imageVersion,omitempty"`
 }
 
 func (c customizer) columns() []string {
-	return []string{c.ID, c.Name}
+	if c.ImageVersion == nil {
+		return []string{c.ID, c.Name, ""}
+	}
+	return []string{c.ID, c.Name, strconv.Itoa(*c.ImageVersion)}
 }
 
-var customizerColumns = []string{"ID", "Name"}
+var customizerColumns = []string{"ID", "Name", "Version"}

--- a/cmd/connector/models.go
+++ b/cmd/connector/models.go
@@ -54,6 +54,18 @@ type TagUpdate struct {
 	ActiveVersion uint32 `json:"activeVersion"`
 }
 
+type instance struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	CustomizerId string `json:"connectorCustomizerId"`
+}
+
+func (c instance) columns() []string {
+	return []string{c.ID, c.Name, c.CustomizerId}
+}
+
+var instanceColumns = []string{"ID", "Name", "Customizer ID"}
+
 type customizer struct {
 	ID           string `json:"id"`
 	Name         string `json:"name"`

--- a/cmd/connector/models.go
+++ b/cmd/connector/models.go
@@ -68,3 +68,15 @@ func (c customizer) columns() []string {
 }
 
 var customizerColumns = []string{"ID", "Name", "Version"}
+
+type customizerVersion struct {
+	CustomizerID string `json:"connectorCustomizerId"`
+	ImageID      string `json:"imageId"`
+	Version      int    `json:"version"`
+}
+
+func (c customizerVersion) columns() []string {
+	return []string{c.CustomizerID, c.ImageID, strconv.Itoa(c.Version)}
+}
+
+var customizerVersionColumns = []string{"Customizer ID", "Image ID", "Version"}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,6 +17,7 @@ type Client interface {
 	Delete(ctx context.Context, url string, params map[string]string) (*http.Response, error)
 	Post(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error)
 	Put(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error)
+	Patch(ctx context.Context, url string, body io.Reader) (*http.Response, error)
 }
 
 // SpClient provides access to SP APIs.
@@ -136,6 +137,35 @@ func (c *SpClient) Put(ctx context.Context, url string, contentType string, body
 		return nil, err
 	}
 	req.Header.Add("Content-Type", contentType)
+	req.Header.Add("Authorization", "Bearer "+c.accessToken)
+
+	if c.cfg.Debug {
+		dbg, _ := httputil.DumpRequest(req, true)
+		fmt.Println(string(dbg))
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cfg.Debug {
+		dbg, _ := httputil.DumpResponse(resp, true)
+		fmt.Println(string(dbg))
+	}
+
+	return resp, nil
+}
+
+func (c *SpClient) Patch(ctx context.Context, url string, body io.Reader) (*http.Response, error) {
+	if err := c.ensureAccessToken(ctx); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.getUrl(url), body)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Add("Authorization", "Bearer "+c.accessToken)
 
 	if c.cfg.Debug {

--- a/internal/mocks/client.go
+++ b/internal/mocks/client.go
@@ -66,6 +66,21 @@ func (mr *MockClientMockRecorder) Get(ctx, url interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), ctx, url)
 }
 
+// Patch mocks base method.
+func (m *MockClient) Patch(ctx context.Context, url string, body io.Reader) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Patch", ctx, url, body)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Patch indicates an expected call of Patch.
+func (mr *MockClientMockRecorder) Patch(ctx, url, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockClient)(nil).Patch), ctx, url, body)
+}
+
 // Post mocks base method.
 func (m *MockClient) Post(ctx context.Context, url, contentType string, body io.Reader) (*http.Response, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/terminal.go
+++ b/internal/mocks/terminal.go
@@ -10,31 +10,31 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTerm is a mock of Term interface.
-type MockTerm struct {
+// MockTerminal is a mock of Terminal interface.
+type MockTerminal struct {
 	ctrl     *gomock.Controller
-	recorder *MockTermMockRecorder
+	recorder *MockTerminalMockRecorder
 }
 
-// MockTermMockRecorder is the mock recorder for MockTerm.
-type MockTermMockRecorder struct {
-	mock *MockTerm
+// MockTerminalMockRecorder is the mock recorder for MockTerminal.
+type MockTerminalMockRecorder struct {
+	mock *MockTerminal
 }
 
-// NewMockTerm creates a new mock instance.
-func NewMockTerm(ctrl *gomock.Controller) *MockTerm {
-	mock := &MockTerm{ctrl: ctrl}
-	mock.recorder = &MockTermMockRecorder{mock}
+// NewMockTerminal creates a new mock instance.
+func NewMockTerminal(ctrl *gomock.Controller) *MockTerminal {
+	mock := &MockTerminal{ctrl: ctrl}
+	mock.recorder = &MockTerminalMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockTerm) EXPECT() *MockTermMockRecorder {
+func (m *MockTerminal) EXPECT() *MockTerminalMockRecorder {
 	return m.recorder
 }
 
 // PromptPassword mocks base method.
-func (m *MockTerm) PromptPassword(promptMsg string) (string, error) {
+func (m *MockTerminal) PromptPassword(promptMsg string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PromptPassword", promptMsg)
 	ret0, _ := ret[0].(string)
@@ -43,7 +43,7 @@ func (m *MockTerm) PromptPassword(promptMsg string) (string, error) {
 }
 
 // PromptPassword indicates an expected call of PromptPassword.
-func (mr *MockTermMockRecorder) PromptPassword(promptMsg interface{}) *gomock.Call {
+func (mr *MockTerminalMockRecorder) PromptPassword(promptMsg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromptPassword", reflect.TypeOf((*MockTerm)(nil).PromptPassword), promptMsg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromptPassword", reflect.TypeOf((*MockTerminal)(nil).PromptPassword), promptMsg)
 }


### PR DESCRIPTION
## Description
Commands to manage connector customizers, including CRUD operation, linking and unblinking with connector instances.

Part 2 of this effort is to have customizer init command. This is just to keep the PR size smaller for review purposes.

## How Has This Been Tested?
Tested manually:
<img width="1082" alt="Screenshot 2023-09-07 at 11 25 00 AM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/42616890/c7f2e095-3cf2-4201-bfb1-79e2f9d718f3">

Ok-ed by Philip!
<img width="338" alt="Screenshot 2023-09-07 at 1 49 45 PM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/42616890/2bbfddbe-393b-43ab-9b65-87191d02c411">
 
