### PR TITLE
Added Sanitize command

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sailpoint-oss/sailpoint-cli/cmd/connector"
 	"github.com/sailpoint-oss/sailpoint-cli/cmd/environment"
 	"github.com/sailpoint-oss/sailpoint-cli/cmd/report"
+	"github.com/sailpoint-oss/sailpoint-cli/cmd/sanitize"
 	"github.com/sailpoint-oss/sailpoint-cli/cmd/sdk"
 	"github.com/sailpoint-oss/sailpoint-cli/cmd/search"
 	"github.com/sailpoint-oss/sailpoint-cli/cmd/set"
@@ -59,6 +60,7 @@ func NewRootCommand() *cobra.Command {
 		transform.NewTransformCommand(),
 		va.NewVACommand(t),
 		workflow.NewWorkflowCommand(),
+		sanitize.NewSanitizeCommand(),
 	)
 
 	root.PersistentFlags().StringVarP(&env, "env", "", "", "Environment to use for SailPoint CLI commands")

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -13,7 +13,7 @@ import (
 
 // Expected number of subcommands to `sail` root command
 const (
-	numRootSubcommands = 11
+	numRootSubcommands = 12
 )
 
 func TestNewRootCmd_noArgs(t *testing.T) {

--- a/cmd/sanitize/sanitize.go
+++ b/cmd/sanitize/sanitize.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2023, SailPoint Technologies, Inc. All rights reserved.
+package sanitize
+
+import (
+	_ "embed"
+	"os"
+	"regexp"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+//go:embed sanitize.md
+var sanitizeHelp string
+
+func NewSanitizeCommand() *cobra.Command {
+	help := util.ParseHelp(sanitizeHelp)
+	cmd := &cobra.Command{
+		Use:     "sanitize",
+		Short:   "Sanitize a file of sensitive data",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			for _, filePath := range args {
+				// Open the file, read it in as plain text, and sanitize it of all access tokens
+				file, err := os.ReadFile(filePath)
+				if err != nil {
+					return err
+				}
+
+				tokens := regexp.MustCompile(`(ey[A-Za-z0-9-_=]+).(ey[A-Za-z0-9-_=]+).[A-Za-z0-9-_.+=]+`)
+				origins := regexp.MustCompile(`\{[\s]+"name": "origin",[\s]+"value":[\s]+"[A-Za-z0-9:\/\-.]+"[\s]+\},`)
+
+				redactedFile := origins.ReplaceAllString(tokens.ReplaceAllString(string(file), "REDACTED"), `{"name":"origin", "value":"REDACTED"},`)
+
+				// Write the sanitized file back to disk
+				err = os.WriteFile(filePath, []byte(redactedFile), 0644)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+
+}

--- a/cmd/sanitize/sanitize.md
+++ b/cmd/sanitize/sanitize.md
@@ -1,7 +1,21 @@
 ==Long==
 # Sanitize
 
-Sanitize a file of sensitive data
+Sanitize a har file of sensitive data
+Specifically removes access tokens and origin urls similar to the examples below:
+
+Access Token
+```
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZW5hbnRfaWQiOiI1OGViMDZhNC1kY2Q3LTRlOTYtOGZhYy1jY2EyYWZjMDNlNjEiLCJpbnRlcm5hbCI6dHJ1ZSwicG9kIjoiY29vayIsIm9yZyI6ImV4YW1wbGUiLCJpZGVudGl0eV9pZCI6ImZmODA4MTgxNTVmZThjMDgwMTU1ZmU4ZDkyNWIwMzE2IiwidXNlcl9uYW1lIjoic2xwdC5zZXJ2aWNlcyIsInN0cm9uZ19hdXRoIjp0cnVlLCJhdXRob3JpdGllcyI6WyJPUkdfQURNSU4iXSwiY2xpZW50X2lkIjoibktCUE93akpIOExYU2pJbCIsInN0cm9uZ19hdXRoX3N1cHBvcnRlZCI6dHJ1ZSwidXNlcl9pZCI6IjU5NTgyNiIsInNjb3BlIjpbInJlYWQiLCJ3cml0ZSJdLCJleHAiOjE1NjU4ODgzMTksImp0aSI6ImM5OGQxMjM2LTQ1MTMtNGM4OS1hMGQwLTBjYjlmMzI3NmI1NiJ9.SAY4ZQkXGi2cY_qz57Ah9_zDq4-bnF-oDJKotXa-LCY
+```
+
+Origin URLs
+```json
+{
+    "name": "origin",
+    "value": "https://example.identitynow.com"
+}
+```
 
 ====
 

--- a/cmd/sanitize/sanitize.md
+++ b/cmd/sanitize/sanitize.md
@@ -1,7 +1,7 @@
 ==Long==
 # Sanitize
 
-Sanitize a har file of sensitive data 
+Sanitize a har file of sensitive data  
 Specifically removes access tokens and origin urls similar to the examples below:
 
 Access Token

--- a/cmd/sanitize/sanitize.md
+++ b/cmd/sanitize/sanitize.md
@@ -1,0 +1,12 @@
+==Long==
+# Sanitize
+
+Sanitize a file of sensitive data
+
+====
+
+==Example==
+```bash
+sail sanitize ./path/to/file.har ./path/to/file.log 
+```
+====

--- a/cmd/sanitize/sanitize.md
+++ b/cmd/sanitize/sanitize.md
@@ -1,7 +1,7 @@
 ==Long==
 # Sanitize
 
-Sanitize a har file of sensitive data
+Sanitize a har file of sensitive data 
 Specifically removes access tokens and origin urls similar to the examples below:
 
 Access Token


### PR DESCRIPTION
## Description
What is the intent of this change and why is it being made?

This change adds a sanitize command that can be used to quickly strip a har file of the most sensitive details prior to uploading on support cases

Command can be used as `sail sanitize ./path/to/file.har`

## How Has This Been Tested?
What testing have you done to verify this change?

This command was tested locally on a handful of har files
