### PR TITLE
PLTCONN-4069: Limit number of account reads

### DIFF
--- a/cmd/connector/conn.go
+++ b/cmd/connector/conn.go
@@ -7,12 +7,13 @@ import (
 	"log"
 	"os"
 
-	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
-	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
-	"github.com/sailpoint-oss/sailpoint-cli/internal/terminal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/terminal"
 )
 
 const (
@@ -40,6 +41,7 @@ func NewConnCmd(term terminal.Terminal) *cobra.Command {
 	Client := client.NewSpClient(Config)
 
 	conn.PersistentFlags().StringP("conn-endpoint", "e", connectorsEndpoint, "Override connectors endpoint")
+	conn.PersistentFlags().Int64("read-limit", accountReadLimit, "Set read limit for accounts and entitlements read")
 
 	conn.AddCommand(
 		newConnInitCommand(),

--- a/cmd/connector/conn_validate.go
+++ b/cmd/connector/conn_validate.go
@@ -48,14 +48,9 @@ func newConnValidateCmd(apiClient client.Client) *cobra.Command {
 			check := cmd.Flags().Lookup("check").Value.String()
 
 			isReadOnly, _ := strconv.ParseBool(cmd.Flags().Lookup("read-only").Value.String())
-			readLimit := cmd.Flags().Lookup("read-limit").Value.String()
-			readLimitVal := int64(accountReadLimit)
-
-			if readLimit != "" {
-				readLimitVal, err = getReadLimitVal(readLimit)
-				if err != nil {
-					return fmt.Errorf("invalid value of readLimit: %v", err)
-				}
+			readLimitVal, err := getReadLimitVal(cmd)
+			if err != nil {
+				return fmt.Errorf("invalid value of readLimit: %v", err)
 			}
 
 			valid := connvalidate.NewValidator(connvalidate.Config{
@@ -115,8 +110,8 @@ func newConnValidateCmd(apiClient client.Client) *cobra.Command {
 	return cmd
 }
 
-func getReadLimitVal(readLimit string) (int64, error) {
-	readLimitVal, err := strconv.ParseInt(readLimit, 10, 64)
+func getReadLimitVal(cmd *cobra.Command) (int64, error) {
+	readLimitVal, err := cmd.Flags().GetInt64("read-limit")
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/connector/conn_validate.go
+++ b/cmd/connector/conn_validate.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/logrusorgru/aurora"
 	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
 	connvalidate "github.com/sailpoint-oss/sailpoint-cli/cmd/connector/validate"
 	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
-	"github.com/spf13/cobra"
 )
 
 func newConnValidateCmd(apiClient client.Client) *cobra.Command {
@@ -43,9 +44,11 @@ func newConnValidateCmd(apiClient client.Client) *cobra.Command {
 			check := cmd.Flags().Lookup("check").Value.String()
 
 			isReadOnly, _ := strconv.ParseBool(cmd.Flags().Lookup("read-only").Value.String())
+			isReadLimit, _ := strconv.ParseBool(cmd.Flags().Lookup("read-limit").Value.String())
 			valid := connvalidate.NewValidator(connvalidate.Config{
-				Check:    check,
-				ReadOnly: isReadOnly,
+				Check:     check,
+				ReadOnly:  isReadOnly,
+				ReadLimit: isReadLimit,
 			}, cc)
 
 			results, err := valid.Run(ctx)

--- a/cmd/connector/conn_validate_sources.go
+++ b/cmd/connector/conn_validate_sources.go
@@ -69,15 +69,9 @@ func newConnValidateSourcesCmd(apiClient client.Client) *cobra.Command {
 			ctx := cmd.Context()
 
 			endpoint := cmd.Flags().Lookup("conn-endpoint").Value.String()
-			readLimit := cmd.Flags().Lookup("read-limit").Value.String()
-			readLimitVal := int64(accountReadLimit)
-			var err error
-
-			if readLimit != "" {
-				readLimitVal, err = getReadLimitVal(readLimit)
-				if err != nil {
-					return fmt.Errorf("invalid value of readLimit: %v", err)
-				}
+			readLimitVal, err := getReadLimitVal(cmd)
+			if err != nil {
+				return fmt.Errorf("invalid value of readLimit: %v", err)
 			}
 
 			listOfSources, err := getSourceFromFile(sourceFile)

--- a/cmd/connector/validate/account_create.go
+++ b/cmd/connector/validate/account_create.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kr/pretty"
+
 	connclient "github.com/sailpoint-oss/sailpoint-cli/cmd/connector/client"
 )
 
@@ -16,7 +17,7 @@ var accountCreateChecks = []Check{
 		RequiredCommands: []string{
 			"std:account:create",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			input := map[string]interface{}{}
 			_, _, err := cc.AccountCreate(ctx, nil, input, nil)
 			if err == nil {
@@ -33,7 +34,7 @@ var accountCreateChecks = []Check{
 			"std:account:read",
 			"std:account:delete",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			input := map[string]interface{}{}
 			for _, field := range spec.AccountCreateTemplate.Fields {
 				if field.Required {
@@ -79,7 +80,7 @@ var accountCreateChecks = []Check{
 			"std:account:read",
 			"std:account:delete",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			input := map[string]interface{}{}
 			for _, field := range spec.AccountCreateTemplate.Fields {
 				input[getFieldName(field)] = genCreateField(field)
@@ -124,7 +125,7 @@ var accountCreateChecks = []Check{
 			"std:account:delete",
 			"std:account:list",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			accountsPreCreate, _, _, err := cc.AccountList(ctx, nil, nil, nil)
 			if err != nil {
 				res.err(err)

--- a/cmd/connector/validate/account_create.go
+++ b/cmd/connector/validate/account_create.go
@@ -17,7 +17,7 @@ var accountCreateChecks = []Check{
 		RequiredCommands: []string{
 			"std:account:create",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			input := map[string]interface{}{}
 			_, _, err := cc.AccountCreate(ctx, nil, input, nil)
 			if err == nil {
@@ -34,7 +34,7 @@ var accountCreateChecks = []Check{
 			"std:account:read",
 			"std:account:delete",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			input := map[string]interface{}{}
 			for _, field := range spec.AccountCreateTemplate.Fields {
 				if field.Required {
@@ -80,7 +80,7 @@ var accountCreateChecks = []Check{
 			"std:account:read",
 			"std:account:delete",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			input := map[string]interface{}{}
 			for _, field := range spec.AccountCreateTemplate.Fields {
 				input[getFieldName(field)] = genCreateField(field)
@@ -125,7 +125,7 @@ var accountCreateChecks = []Check{
 			"std:account:delete",
 			"std:account:list",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			accountsPreCreate, _, _, err := cc.AccountList(ctx, nil, nil, nil)
 			if err != nil {
 				res.err(err)

--- a/cmd/connector/validate/account_read.go
+++ b/cmd/connector/validate/account_read.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/kr/pretty"
+
 	connclient "github.com/sailpoint-oss/sailpoint-cli/cmd/connector/client"
 )
 
@@ -24,14 +25,17 @@ var accountReadChecks = []Check{
 				res.err(err)
 				return
 			}
-
+			count := 0
 			for _, account := range accounts {
+				if count > accountReadLimit {
+					break
+				}
 				acct, _, err := cc.AccountRead(ctx, account.ID(), account.UniqueID(), nil)
 				if err != nil {
 					res.err(err)
 					return
 				}
-
+				count++
 				if acct.Identity != account.Identity {
 					res.errf("want %q; got %q", account.Identity, acct.Identity)
 				}

--- a/cmd/connector/validate/account_read.go
+++ b/cmd/connector/validate/account_read.go
@@ -27,7 +27,7 @@ var accountReadChecks = []Check{
 				return
 			}
 			if len(accounts) == 0 {
-				res.warnf("no entitlements")
+				res.warnf("no accounts")
 				return
 			}
 
@@ -36,7 +36,7 @@ var accountReadChecks = []Check{
 			})
 			count := int64(0)
 			for _, account := range accounts {
-				if count > readLimit {
+				if count == readLimit {
 					break
 				}
 				acct, _, err := cc.AccountRead(ctx, account.ID(), account.UniqueID(), nil)

--- a/cmd/connector/validate/account_read.go
+++ b/cmd/connector/validate/account_read.go
@@ -19,7 +19,7 @@ var accountReadChecks = []Check{
 			"std:account:read",
 			"std:account:list",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			accounts, _, _, err := cc.AccountList(ctx, nil, nil, nil)
 			if err != nil {
 				res.err(err)
@@ -27,7 +27,7 @@ var accountReadChecks = []Check{
 			}
 			count := 0
 			for _, account := range accounts {
-				if count > accountReadLimit {
+				if readLimit && count > accountReadLimit {
 					break
 				}
 				acct, _, err := cc.AccountRead(ctx, account.ID(), account.UniqueID(), nil)
@@ -59,7 +59,7 @@ var accountReadChecks = []Check{
 		RequiredCommands: []string{
 			"std:account:read",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			_, _, err := cc.AccountRead(ctx, "__sailpoint__not__found__", "", nil)
 			if err == nil {
 				res.errf("expected error for non-existant identity")
@@ -73,7 +73,7 @@ var accountReadChecks = []Check{
 		RequiredCommands: []string{
 			"std:account:list",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			additionalAttributes := map[string]string{}
 
 			attrsByName := map[string]connclient.AccountSchemaAttribute{}

--- a/cmd/connector/validate/account_read.go
+++ b/cmd/connector/validate/account_read.go
@@ -34,9 +34,9 @@ var accountReadChecks = []Check{
 			rand.Shuffle(len(accounts), func(i, j int) {
 				accounts[i], accounts[j] = accounts[j], accounts[i]
 			})
-			count := int64(0)
-			for _, account := range accounts {
-				if count == readLimit {
+
+			for index, account := range accounts {
+				if int64(index) == readLimit {
 					break
 				}
 				acct, _, err := cc.AccountRead(ctx, account.ID(), account.UniqueID(), nil)
@@ -44,7 +44,6 @@ var accountReadChecks = []Check{
 					res.err(err)
 					return
 				}
-				count++
 				if acct.Identity != account.Identity {
 					res.errf("want %q; got %q", account.Identity, acct.Identity)
 				}

--- a/cmd/connector/validate/account_update.go
+++ b/cmd/connector/validate/account_update.go
@@ -17,7 +17,7 @@ var accountUpdateChecks = []Check{
 			"std:account:list",
 			"std:account:update",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			accounts, _, _, err := cc.AccountList(ctx, nil, nil, nil)
 			if err != nil {
 				res.err(err)
@@ -72,7 +72,7 @@ var accountUpdateChecks = []Check{
 			"std:account:update",
 			"std:account:delete",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			entitlementAttr := entitlementAttr(spec)
 			if entitlementAttr == "" {
 				res.warnf("no entitlement attribute")

--- a/cmd/connector/validate/account_update.go
+++ b/cmd/connector/validate/account_update.go
@@ -17,7 +17,7 @@ var accountUpdateChecks = []Check{
 			"std:account:list",
 			"std:account:update",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			accounts, _, _, err := cc.AccountList(ctx, nil, nil, nil)
 			if err != nil {
 				res.err(err)
@@ -72,7 +72,7 @@ var accountUpdateChecks = []Check{
 			"std:account:update",
 			"std:account:delete",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			entitlementAttr := entitlementAttr(spec)
 			if entitlementAttr == "" {
 				res.warnf("no entitlement attribute")

--- a/cmd/connector/validate/check.go
+++ b/cmd/connector/validate/check.go
@@ -24,7 +24,7 @@ type Check struct {
 
 	// IsDataModifier determines a checking that will modify connectors data after applying
 	IsDataModifier bool
-	Run            func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult)
+	Run            func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool)
 	// RequiredCommands represents a list of commands that use for this check
 	RequiredCommands []string
 }

--- a/cmd/connector/validate/check.go
+++ b/cmd/connector/validate/check.go
@@ -24,7 +24,7 @@ type Check struct {
 
 	// IsDataModifier determines a checking that will modify connectors data after applying
 	IsDataModifier bool
-	Run            func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool)
+	Run            func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64)
 	// RequiredCommands represents a list of commands that use for this check
 	RequiredCommands []string
 }

--- a/cmd/connector/validate/entitlement_read.go
+++ b/cmd/connector/validate/entitlement_read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/kr/pretty"
+
 	connclient "github.com/sailpoint-oss/sailpoint-cli/cmd/connector/client"
 )
 
@@ -42,14 +43,17 @@ var entitlementReadChecks = []Check{
 				res.warnf("no entitlements")
 				return
 			}
-
+			count := 0
 			for _, e := range entitlements {
+				if count > accountReadLimit {
+					break
+				}
 				eRead, _, err := cc.EntitlementRead(ctx, e.ID(), e.UniqueID(), "group", nil)
 				if err != nil {
 					res.errf("failed to read entitlement %q: %s", e.Identity, err.Error())
 					return
 				}
-
+				count++
 				if e.Identity != eRead.Identity {
 					res.errf("want %q; got %q", e.Identity, eRead.Identity)
 				}

--- a/cmd/connector/validate/entitlement_read.go
+++ b/cmd/connector/validate/entitlement_read.go
@@ -51,7 +51,7 @@ var entitlementReadChecks = []Check{
 
 			count := int64(0)
 			for _, e := range entitlements {
-				if count > readLimit {
+				if count == readLimit {
 					break
 				}
 				eRead, _, err := cc.EntitlementRead(ctx, e.ID(), e.UniqueID(), "group", nil)

--- a/cmd/connector/validate/entitlement_read.go
+++ b/cmd/connector/validate/entitlement_read.go
@@ -49,9 +49,8 @@ var entitlementReadChecks = []Check{
 				entitlements[i], entitlements[j] = entitlements[j], entitlements[i]
 			})
 
-			count := int64(0)
-			for _, e := range entitlements {
-				if count == readLimit {
+			for index, e := range entitlements {
+				if int64(index) == readLimit {
 					break
 				}
 				eRead, _, err := cc.EntitlementRead(ctx, e.ID(), e.UniqueID(), "group", nil)
@@ -59,7 +58,6 @@ var entitlementReadChecks = []Check{
 					res.errf("failed to read entitlement %q: %s", e.Identity, err.Error())
 					return
 				}
-				count++
 				if e.Identity != eRead.Identity {
 					res.errf("want %q; got %q", e.Identity, eRead.Identity)
 				}

--- a/cmd/connector/validate/entitlement_read.go
+++ b/cmd/connector/validate/entitlement_read.go
@@ -16,7 +16,7 @@ var entitlementReadChecks = []Check{
 		RequiredCommands: []string{
 			"std:entitlement:read",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			_, _, err := cc.EntitlementRead(ctx, "__sailpoint__not__found__", "", "group", nil)
 			if err == nil {
 				res.errf("expected error for non-existant entitlement")
@@ -32,7 +32,7 @@ var entitlementReadChecks = []Check{
 			"std:entitlement:read",
 			"std:entitlement:list",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			entitlements, _, _, err := cc.EntitlementList(ctx, "group", nil, nil, nil)
 			if err != nil {
 				res.err(err)
@@ -45,7 +45,7 @@ var entitlementReadChecks = []Check{
 			}
 			count := 0
 			for _, e := range entitlements {
-				if count > accountReadLimit {
+				if readLimit && count > accountReadLimit {
 					break
 				}
 				eRead, _, err := cc.EntitlementRead(ctx, e.ID(), e.UniqueID(), "group", nil)
@@ -73,7 +73,7 @@ var entitlementReadChecks = []Check{
 		RequiredCommands: []string{
 			"std:entitlement:list",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			additionalAttributes := map[string]string{}
 
 			attrsByName := map[string]connclient.EntitlementSchemaAttribute{}

--- a/cmd/connector/validate/test_conn.go
+++ b/cmd/connector/validate/test_conn.go
@@ -15,7 +15,7 @@ var testConnChecks = []Check{
 		RequiredCommands: []string{
 			"std:test-connection",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			err := cc.TestConnectionWithConfig(ctx, json.RawMessage("{}"))
 			if err == nil {
 				res.errf("expected test-connection failure for empty config")
@@ -29,7 +29,7 @@ var testConnChecks = []Check{
 		RequiredCommands: []string{
 			"std:test-connection",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit int64) {
 			_, err := cc.TestConnection(ctx)
 			if err != nil {
 				res.err(err)

--- a/cmd/connector/validate/test_conn.go
+++ b/cmd/connector/validate/test_conn.go
@@ -15,7 +15,7 @@ var testConnChecks = []Check{
 		RequiredCommands: []string{
 			"std:test-connection",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			err := cc.TestConnectionWithConfig(ctx, json.RawMessage("{}"))
 			if err == nil {
 				res.errf("expected test-connection failure for empty config")
@@ -29,7 +29,7 @@ var testConnChecks = []Check{
 		RequiredCommands: []string{
 			"std:test-connection",
 		},
-		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult) {
+		Run: func(ctx context.Context, spec *connclient.ConnSpec, cc *connclient.ConnClient, res *CheckResult, readLimit bool) {
 			_, err := cc.TestConnection(ctx)
 			if err != nil {
 				res.err(err)

--- a/cmd/connector/validate/util.go
+++ b/cmd/connector/validate/util.go
@@ -12,6 +12,10 @@ import (
 	connclient "github.com/sailpoint-oss/sailpoint-cli/cmd/connector/client"
 )
 
+const (
+	accountReadLimit = 8
+)
+
 // entitlementAttr returns the attribute for entitlements
 func entitlementAttr(spec *connclient.ConnSpec) string {
 	for _, attr := range spec.AccountSchema.Attributes {

--- a/cmd/connector/validate/util.go
+++ b/cmd/connector/validate/util.go
@@ -12,10 +12,6 @@ import (
 	connclient "github.com/sailpoint-oss/sailpoint-cli/cmd/connector/client"
 )
 
-const (
-	accountReadLimit = 8
-)
-
 // entitlementAttr returns the attribute for entitlements
 func entitlementAttr(spec *connclient.ConnSpec) string {
 	for _, attr := range spec.AccountSchema.Attributes {

--- a/cmd/connector/validate/validate.go
+++ b/cmd/connector/validate/validate.go
@@ -28,6 +28,10 @@ type Config struct {
 	// ReadOnly specifies a type of validation.
 	// If ReadOnly set 'true' validator will run all checks that don't make any modifications.
 	ReadOnly bool
+
+	// ReadLimit specifies whether to limit the number of account read
+	// If ReadLimit set 'true', check for account and entitlement read will only read 8 accounts
+	ReadLimit bool
 }
 
 // NewValidator creates a new validator with provided config and ConnClient
@@ -62,7 +66,7 @@ func (v *Validator) Run(ctx context.Context) (results []CheckResult, err error) 
 		}
 
 		if ok, results := isCheckPossible(spec.Commands, check.RequiredCommands); ok {
-			check.Run(ctx, spec, v.cc, res)
+			check.Run(ctx, spec, v.cc, res, v.cfg.ReadLimit)
 		} else {
 			res.skipf("Skipping check due to unimplemented commands on a connector: %s", strings.Join(results, ", "))
 		}

--- a/cmd/connector/validate/validate.go
+++ b/cmd/connector/validate/validate.go
@@ -31,7 +31,7 @@ type Config struct {
 
 	// ReadLimit specifies whether to limit the number of account read
 	// If ReadLimit set 'true', check for account and entitlement read will only read 8 accounts
-	ReadLimit bool
+	ReadLimit int64
 }
 
 // NewValidator creates a new validator with provided config and ConnClient


### PR DESCRIPTION
## Description
What is the intent of this change and why is it being made? Limit number of account reads for account and entitlement read.

## How Has This Been Tested?
What testing have you done to verify this change? Local tests. Test cases cover with different threshold limit as well as default values.

<img width="1662" alt="Screenshot 2023-11-07 at 11 02 35 AM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/112025406/163a278e-18c3-4cb2-a441-ead6d172a951">

<img width="1662" alt="Screenshot 2023-11-07 at 11 05 19 AM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/112025406/82813e0a-e391-4e44-8f0f-ab4a9c6e2994">

<img width="1662" alt="Screenshot 2023-11-07 at 11 06 15 AM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/112025406/cb04bb5f-915a-459c-afd4-500d5c163e5b">

<img width="1662" alt="Screenshot 2023-11-07 at 11 07 56 AM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/112025406/0c9e7d76-286e-4beb-a2b1-ab323e04cbdc">


<img width="1662" alt="Screenshot 2023-11-07 at 11 09 35 AM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/112025406/ac500fc8-0030-43a5-8229-b778bc432322">

<img width="1192" alt="Screenshot 2023-11-07 at 11 24 20 AM" src="https://github.com/sailpoint-oss/sailpoint-cli/assets/112025406/7f4e7300-edd1-47eb-9fdb-20d46bb564b1">


