### PR TITLE
Update golang mod file to specify latest for golang-sdk version requi…

### DIFF
--- a/cmd/sdk/golang/go.mod.file
+++ b/cmd/sdk/golang/go.mod.file
@@ -2,7 +2,7 @@ module sdk
 
 go 1.18
 
-require github.com/sailpoint-oss/golang-sdk v1.0.1
+require github.com/sailpoint-oss/golang-sdk latest
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect


### PR DESCRIPTION
…rement

## Description
What is the intent of this change and why is it being made?

When you initialize a go project using `sail sdk init golang` it creates a go.mod file with an old version of the sdk `v1.0.1`.

Changing this hardcoded version to `latest` will resolve the latest version available when a user runs `go mod tidy` within the generated project.

## How Has This Been Tested?
What testing have you done to verify this change?

Updated go.mod file in sdk example to `latest` version. Ran `go mod tidy` to verify that it resolves to the latest version, currently `v1.2.0`
