### PR TITLE
Removed all references to cc endpoints

### DIFF
--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -8,7 +8,6 @@ import (
 const (
 	transformsEndpoint      = "/v3/transforms"
 	identityProfileEndpoint = "/v3/identity-profiles"
-	userEndpoint            = "/cc/api/identity/list"
 )
 
 func NewTransformCommand() *cobra.Command {


### PR DESCRIPTION
## Description
The cc endpoints are being deprecated, so we need to remove all references to them in the CLI.

## How Has This Been Tested?
The endpoint I removed is not being used by any commands. It was left over from the transform preview command that was deleted in a previous release.
