### PR TITLE
SAASTRIAGE-8246: Correct reversion of link/unlink commands

### DIFF
--- a/cmd/connector/customizer_link.go
+++ b/cmd/connector/customizer_link.go
@@ -33,7 +33,7 @@ func newCustomizerLinkCmd(client client.Client) *cobra.Command {
 				return err
 			}
 
-			resp, err := client.Patch(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint, instanceID, "link"), bytes.NewReader(raw), nil)
+			resp, err := client.Patch(cmd.Context(), util.ResourceUrl(connectorInstancesEndpoint, instanceID), bytes.NewReader(raw), nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/connector/customizer_unlink.go
+++ b/cmd/connector/customizer_unlink.go
@@ -31,7 +31,7 @@ func newCustomizerUnlinkCmd(client client.Client) *cobra.Command {
 				return err
 			}
 
-			resp, err := client.Patch(cmd.Context(), util.ResourceUrl(connectorCustomizersEndpoint, instanceID, "unlink"), bytes.NewReader(raw), nil)
+			resp, err := client.Patch(cmd.Context(), util.ResourceUrl(connectorInstancesEndpoint, instanceID), bytes.NewReader(raw), nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description
Correct the reverts on the link and unlink command to match their pre-April state

## How Has This Been Tested?
What testing have you done to verify this change?
