### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prb_linux.yml
+++ b/.github/workflows/prb_linux.yml
@@ -1,4 +1,6 @@
 name: PRB_Linux
+permissions:
+  contents: read
 env:
   SAIL_CLIENT_ID: ${{ secrets.SDK_TEST_TENANT_CLIENT_ID }}
   SAIL_CLIENT_SECRET: ${{ secrets.SDK_TEST_TENANT_CLIENT_SECRET }}


### PR DESCRIPTION
Potential fix for [https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/13](https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/13)

To fix this problem, add an explicit `permissions` block to the workflow. The best method is to define a minimal permissions set at the top level, which applies as a default to all jobs (unless overridden). Based on the workflow provided, it runs builds, tests, and uploads artifacts, but does not interact with repository contents (other than possibly needing to checkout code). For these operations, a minimal `contents: read` permission is usually sufficient. Therefore, add:

```yaml
permissions:
  contents: read
```

directly after the `name` or `env` key, before `on:`. This ensures all jobs in the workflow do not have excess permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
