### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prb_macos.yml
+++ b/.github/workflows/prb_macos.yml
@@ -1,4 +1,6 @@
 name: PRB_macOS
+permissions:
+  contents: read
 env:
   SAIL_CLIENT_ID: ${{ secrets.SDK_TEST_TENANT_CLIENT_ID }}
   SAIL_CLIENT_SECRET: ${{ secrets.SDK_TEST_TENANT_CLIENT_SECRET }}


### PR DESCRIPTION
Potential fix for [https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/14](https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/14)

The best way to fix this issue is to explicitly limit the GITHUB_TOKEN permissions for this workflow to the least privilege necessary. Since this workflow does not appear to update repository contents, issues, or perform other write actions (it just checks out code, sets up the environment, runs tests, and uploads artifacts), the minimal required permission is almost certainly `contents: read` (so that it can check out the repository's code). This permission should be set as high as possible in the workflow, preferably at the workflow level, by adding a `permissions:` block just below the `name:` or above the `env:` key at the workflow root. This way, all jobs and steps inherit this setting unless a more specific override is required later.

**Steps:**
- Add the following block at the top of the file, just after the `name:` line and before `env:`, or as the second key in the workflow YAML:
  ```yaml
  permissions:
    contents: read
  ```
- No other changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
