### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prb_windows.yml
+++ b/.github/workflows/prb_windows.yml
@@ -1,4 +1,6 @@
 name: PRB_Windows
+permissions:
+  contents: read
 env:
   SAIL_CLIENT_ID: ${{ secrets.SDK_TEST_TENANT_CLIENT_ID }}
   SAIL_CLIENT_SECRET: ${{ secrets.SDK_TEST_TENANT_CLIENT_SECRET }}


### PR DESCRIPTION
Potential fix for [https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/15](https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/15)

The fix is to add a `permissions` block explicitly granting only those privileges that are required. Because the job checks out code and uploads an artifact, the minimal safe permission is `contents: read`. If any of the actions needed to create or modify pull requests or issues, more granular write permissions would be required, but in this workflow that's unnecessary. Therefore, the best fix is to add:

```yaml
permissions:
  contents: read
```

...at the root of the workflow file, so it applies to all jobs unless overridden (alternatively, immediately under the job is also valid). The block should be placed after the `name:` and (optionally) before/after `env:`—conventionally, immediately after `name:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
