### PR TITLE
Potential fix for code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/cmd/connector/conn_tag_update.go
+++ b/cmd/connector/conn_tag_update.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -30,7 +31,9 @@ func newConnTagUpdateCmd(client client.Client) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
+			if version < 0 || version > int(math.MaxUint32) {
+				return fmt.Errorf("active version must be between 0 and %d", math.MaxUint32)
+			}
 			raw, err := json.Marshal(TagUpdate{ActiveVersion: uint32(version)})
 			if err != nil {
 				return err


### PR DESCRIPTION
Potential fix for [https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/5](https://github.com/sailpoint-oss/sailpoint-cli/security/code-scanning/5)

The best way to fix this problem is to validate the numeric value parsed from the string, ensuring it is both non-negative and does not exceed the maximum value representable by a `uint32` (4294967295). For simplicity and security, perform this validation immediately after parsing: if the value is invalid (negative or too large), return an error or use a default/alternative value as appropriate. You should import the `math` package, use its `MaxUint32` constant, and perform an explicit bounds check before casting.

Changes are required in `cmd/connector/conn_tag_update.go`, specifically in the block where the value is parsed and cast in lines 29–34. You should:
- Import `"math"`
- Check that `version` does not exceed `math.MaxUint32` and is non-negative.
- Return an error if the check fails or fallback to a default value.

No additional methods or definitions are needed beyond using these checks inline.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
