### PR TITLE
Fix .goreleaser so that deb and rpm packages are built to deploy sail to /usr/bin

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,7 +72,7 @@ nfpms:
   - license: MIT
     maintainer: SailPoint
     homepage: https://github.com/sailpoint-oss/sailpoint-cli
-    bindir: /usr
+    bindir: /usr/bin/
     description: The SailPoint Command Line Interface.
     formats:
       - deb


### PR DESCRIPTION
## Description
Currently the downloadable deb and rpm packages available for each release will install / deploy the sail cli directly to the the **/usr/** directory on linux systems when using the SailPoint recommended sudo apt install ./release.deb. 

This violates the linux [Filesystem Hierarchy Standard](https://www.debian.org/doc/packaging-manuals/fhs/fhs-3.0.html#theUsrHierarchy) and filesystem best practice for Debian and Red Hat based linux distributions. 

More importantly if a user follows the directions recommend to install the package from the docs it will likely cause an issue for them because /usr/ is not in the default PATH variable for those distributions like /usr/bin is. So executing 'sail' will not work right away. 

## How Has This Been Tested?
1. Made the change in my local. 
2. Built the project locally using goreleaser release --snapshot --clean
3. Installed the created .deb package in Ubuntu 24.04
4. Ran which sail -- output /usr/bin
5. Ran the sail command -- works right away. 
6. Installed the .rpm package in Fedora 42
7. Ran which sail -- output /usr/bin
8. Ran the sail command -- works right away.

- Only tested amd64 deb and rpm packages as I only have access to that architecture. Should be the same for all. 

## Changes
In the .goreleaser.yaml file simply change the bindir property under **nfpms**

## Reasoning
- Per FHS package manager managed packages should install under /usr/bin
- Better for users as they do not have to add /usr/ directory to PATH variable or copy 'sail' manually to another directory. 
- Installing directly in /usr/ and not it's sub-directories is prohibited by FHS