### PR TITLE
fix: prevent file corruption in transform download

### DIFF
--- a/cmd/transform/download.go
+++ b/cmd/transform/download.go
@@ -3,9 +3,10 @@ package transform
 
 import (
 	"context"
-	"strings"
+	"fmt"
 
 	"github.com/charmbracelet/log"
+	"github.com/mrz1836/go-sanitize"
 	sailpoint "github.com/sailpoint-oss/golang-sdk/v2"
 	v3 "github.com/sailpoint-oss/golang-sdk/v2/api_v3"
 	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
@@ -35,8 +36,14 @@ func newDownloadCommand() *cobra.Command {
 				return sdk.HandleSDKError(resp, err)
 			}
 
+			filenameCounts := make(map[string]int)
 			for _, v := range transforms {
-				filename := strings.ReplaceAll(v.Name, " ", "")
+				baseName := sanitize.PathName(v.Name)
+				filename := baseName
+				if count := filenameCounts[baseName]; count > 0 {
+					filename = fmt.Sprintf("%s-%d", baseName, count)
+				}
+				filenameCounts[baseName]++
 
 				err := output.SaveJSONFile(v, filename, destination)
 				if err != nil {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -43,7 +43,8 @@ func WriteFile(folderPath string, filePath string, data []byte) error {
 		}
 	}
 
-	file, err := os.OpenFile(path.Join(folderPath, filePath), os.O_CREATE|os.O_RDWR, 0777)
+	// O_TRUNC ensures existing file content is removed before writing
+	file, err := os.OpenFile(path.Join(folderPath, filePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0777)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
he `sail transform download` command produces corrupted JSON files in two scenarios:

**1. Re-downloading to existing folder**

`WriteFile` uses `O_CREATE|O_RDWR` without `O_TRUNC`. When new content is shorter than existing file content, leftover bytes remain, producing invalid JSON.

**2. Filename collisions**

Transform names like "AD - samAccountName" and "AD-samAccountName" both sanitize to `AD-samAccountName.json`. The second overwrites the first, and combined with bug #1, produces merged/corrupted content.

## Changes

- Add `O_TRUNC` flag to `WriteFile` to properly truncate existing files
- Add filename collision detection using in-memory map (appends `-1`, `-2`, etc.)
- Use `sanitize.PathName` directly instead of manual space stripping
- Change `O_RDWR` to `O_WRONLY` (write-only, since we never read)

### Bug: Missing O_TRUNC

**Original file (first download):**
```json
{
  "name": "ToUpper",
  "type": "upper",
  "attributes": {
    "input": { "type": "identityAttribute" }
  }
}
```

**After transform is updated and re-downloaded (shorter content):**
```json
{
  "name": "ToUpper",
  "type": "upper"
}put": { "type": "identityAttribute" }
  }
}
```

### Bug: Filename Collision

**First transform written:**
```json
{
  "name": "AD - samAccountName",
  "type": "accountAttribute",
  "attributes": {
    "sourceName": "Active Directory"
  }
}
```

**Second transform overwrites (shorter, same sanitized filename):**
```json
{
  "name": "AD-samAccountName",
  "type": "static"
}ountAttribute",
  "attributes": {
    "sourceName": "Active Directory"
  }
}
```

### After Fix

```
transforms/
├── AD-samAccountName.json    # first transform preserved
├── AD-samAccountName-1.json  # collision handled
└── ToUpper.json              # clean on re-download (O_TRUNC)
```
