### PR TITLE
Refactor: Saas Connector template

### DIFF
--- a/cmd/connector/static/connector/jest-config.cjs
+++ b/cmd/connector/static/connector/jest-config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  collectCoverage: true,
+  testMatch: ["**/**/*.test.ts", "**/**/*.spec.ts"],
+  moduleFileExtensions: ["ts", "js", "json"]
+};

--- a/cmd/connector/static/connector/package.json
+++ b/cmd/connector/static/connector/package.json
@@ -25,7 +25,8 @@
     "shx": "^0.3.3",
     "ts-jest": "^27.0.5",
     "typescript": "^4.9.5",
-    "cross-env": "7.0.3"
+    "cross-env": "7.0.3",
+    "@types/node": "^25.9.1"
   },
   "jest": {
     "preset": "ts-jest",

--- a/cmd/connector/static/connector/src/index.spec.ts
+++ b/cmd/connector/static/connector/src/index.spec.ts
@@ -21,6 +21,10 @@ describe('connector unit tests', () => {
             },
             assumeAwsRole(assumeAwsRoleRequest: AssumeAwsRoleRequest): Promise<AssumeAwsRoleResponse> {
                 return Promise.resolve(new AssumeAwsRoleResponse('accessKeyId', 'secretAccessKey', 'sessionToken', "123"))
+            },
+
+             getOAuth2AccessToken() {
+                return Promise.resolve({} as any)
             }
         },
             undefined,

--- a/cmd/connector/static/connector/tsconfig.json
+++ b/cmd/connector/static/connector/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "jest"],
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.spec.js"]


### PR DESCRIPTION
Used a types for node and jest, included jest config for test

Added getOAuth2AccessToken() mock method to compile the test cases

## Description
What is the intent of this change and why is it being made?

This PR updates the default SailPoint SaaS connector template to compile and run tests cleanly in a local TypeScript/Jest development environment.

Changes made:

- Added Node and Jest type support so TypeScript can recognize `node`, `describe`, `it`, and `expect`.
- Added Jest configuration for running TypeScript test files through `ts-jest`.
- Added the required `getOAuth2AccessToken()` mock method to the test `Context` object so the generated test cases compile against the current SailPoint Connector SDK interface.


## How Has This Been Tested?
What testing have you done to verify this change?

I verified the change by compiling the Go binary, using it to generate a new SaaS connector project, and then running the generated connector test suite with `npm test`.

The test confirmed that the generated connector template now compiles successfully, the TypeScript/Jest setup works correctly, and the default connector unit tests pass after adding the required `getOAuth2AccessToken()` mock method to the SailPoint SDK `Context` object.

The successful `npm test` output has been attached as evidence.
<img width="877" height="305" alt="Screenshot 2026-05-23 at 08 52 08" src="https://github.com/user-attachments/assets/d61b92e2-ec27-4e12-b275-86cc3c6e9646" />


