### PR TITLE
Surface SailApps confirmation code during OAuth login

### DIFF
--- a/internal/config/oauth.go
+++ b/internal/config/oauth.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -59,6 +60,16 @@ type AuthResponse struct {
 	ID      string `json:"id"`
 	BaseURL string `json:"baseURL"`
 	TTL     int64  `json:"ttl"`
+}
+
+func confirmationCodeFromID(id string) string {
+	id = strings.TrimSpace(id)
+	if len(id) < 8 {
+		return strings.ToUpper(id)
+	}
+
+	suffix := id[len(id)-8:]
+	return strings.ToUpper(suffix[:4] + "-" + suffix[4:])
 }
 
 // OAuthTokenResponse represents the response containing the encrypted token from OAuth flow
@@ -415,6 +426,9 @@ func OAuthLogin() (TokenSet, error) {
 	}
 
 	log.Debug("Auth response received", "id", authResponse.ID, "baseURL", authResponse.BaseURL)
+	if confirmationCode := confirmationCodeFromID(authResponse.ID); confirmationCode != "" {
+		fmt.Printf("SailApps confirmation code: %s\n", confirmationCode)
+	}
 
 	// Update the base URL for this session
 	if authResponse.BaseURL != "" {

--- a/internal/config/oauth_test.go
+++ b/internal/config/oauth_test.go
@@ -1,0 +1,40 @@
+package config
+
+import "testing"
+
+func TestConfirmationCodeFromID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{
+			name: "uuid uses last eight characters",
+			id:   "12345678-90ab-cdef-1234-567890abcdef",
+			want: "90AB-CDEF",
+		},
+		{
+			name: "short id is uppercased",
+			id:   "abc123",
+			want: "ABC123",
+		},
+		{
+			name: "whitespace is ignored",
+			id:   "  12345678-90ab-cdef-1234-567890abcdef  ",
+			want: "90AB-CDEF",
+		},
+		{
+			name: "empty id stays empty",
+			id:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := confirmationCodeFromID(tt.id); got != tt.want {
+				t.Fatalf("confirmationCodeFromID(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Prints the SailApps confirmation code during OAuth login so users can verify the browser approval page matches the CLI session.
- Derives the code from the auth session UUID using the same last-eight-character, `XXXX-XXXX` format shown by the SailApps page.
- Adds unit coverage for confirmation code formatting edge cases.

## Test plan
- `GOWORK=off go test -count=1 ./internal/config`
- `GOWORK=off go build ./...`


Made with [Cursor](https://cursor.com)