### PR TITLE
CSTM-193: UI Plugins Create Command

### DIFF
--- a/cmd/ui_plugins/create.go
+++ b/cmd/ui_plugins/create.go
@@ -3,18 +3,27 @@ package ui_plugins
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 
 	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
 	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
-const pluginInstancesEndpoint = "/v2026/ui-plugins"
+//go:embed create.md
+var createHelp string
+
+const (
+	pluginInstancesEndpoint = "/v2026/ui-plugins"
+	validateAliasEndpoint   = pluginInstancesEndpoint + "/validate-alias"
+)
 
 func newCreateCommand() *cobra.Command {
 	var private bool
@@ -22,10 +31,13 @@ func newCreateCommand() *cobra.Command {
 	var dryRun bool
 	var jsonOutput bool
 
+	help := util.ParseHelp(createHelp)
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a UI plugin instance in the current tenant",
-		Args:  cobra.NoArgs,
+		Use:     "create",
+		Short:   "Create a UI plugin instance in the current tenant",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := createConfig{
 				private:         private,
@@ -34,21 +46,15 @@ func newCreateCommand() *cobra.Command {
 				jsonOutput:      jsonOutput,
 			}
 
-			// The client is only needed on the non-dry-run path; a dry run never
-			// touches config or the network.
-			var spClient client.Client
-			if !dryRun {
-				if err := config.InitConfig(); err != nil {
-					return err
-				}
-				cliConfig, err := config.GetConfig()
-				if err != nil {
-					return err
-				}
-				spClient = client.NewSpClient(cliConfig)
+			// A dry run still calls the read-only validate-alias endpoint, so it
+			// needs a client too. Tolerate a missing client on a dry run so the
+			// payload preview still prints when config/auth is unavailable.
+			spClient, clientErr := newPluginClient()
+			if !dryRun && clientErr != nil {
+				return clientErr
 			}
 
-			return runCreate(context.Background(), spClient, manifestFileName, cmd.OutOrStdout(), config.GetCurrentIdentityID, opts)
+			return runCreate(context.Background(), spClient, manifestFileName, cmd.OutOrStdout(), cmd.ErrOrStderr(), config.GetCurrentIdentityID, opts)
 		},
 	}
 
@@ -68,12 +74,25 @@ type createConfig struct {
 	jsonOutput      bool
 }
 
+// newPluginClient builds an authenticated client from the active CLI config.
+func newPluginClient() (client.Client, error) {
+	if err := config.InitConfig(); err != nil {
+		return nil, err
+	}
+	cliConfig, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	return client.NewSpClient(cliConfig), nil
+}
+
 // runCreate loads and validates the workspace manifest at manifestPath, applies
-// visibility overrides, then either prints the payload (dry run) or POSTs it via
-// the provided client and renders the result. The client is only used on the
-// non-dry-run path, so callers may pass nil for a dry run. currentUser resolves
-// the GUID for --private and is injected for testability.
-func runCreate(ctx context.Context, c client.Client, manifestPath string, out io.Writer, currentUser func() (string, error), opts createConfig) error {
+// visibility overrides, then either previews the payload (dry run, with a
+// best-effort alias availability check) or POSTs it via the provided client and
+// renders the result. currentUser resolves the GUID for --private and is injected
+// for testability. The payload preview is written to out; advisory notes from the
+// dry-run alias check are written to errOut.
+func runCreate(ctx context.Context, c client.Client, manifestPath string, out io.Writer, errOut io.Writer, currentUser func() (string, error), opts createConfig) error {
 	cfg, err := loadAndValidateWorkspaceManifest(manifestPath)
 	if err != nil {
 		return err
@@ -94,7 +113,7 @@ func runCreate(ctx context.Context, c client.Client, manifestPath string, out io
 
 	if opts.dryRun {
 		_, _ = fmt.Fprintln(out, string(payload))
-		return nil
+		return checkAliasAvailability(ctx, c, errOut, cfg.Manifest.Alias)
 	}
 
 	headers := map[string]string{"Accept": "application/json"}
@@ -119,6 +138,42 @@ func runCreate(ctx context.Context, c client.Client, manifestPath string, out io
 	}
 
 	return renderCreateSuccess(out, body, cfg.Manifest.Alias)
+}
+
+// checkAliasAvailability performs a best-effort dry-run pre-check against the UMS
+// validate-alias endpoint (GET, read-only). It returns a non-nil error only when the
+// backend gives a definitive negative answer — the alias is already taken (409) or
+// invalid (400) — so a dry run surfaces a create that would fail. Every other outcome
+// (no client, transport error, or an inconclusive status such as 401/403/404 while the
+// route is not yet externally accessible) is reported to errOut and treated as
+// non-fatal, leaving the printed payload as the dry-run result.
+func checkAliasAvailability(ctx context.Context, c client.Client, errOut io.Writer, alias string) error {
+	if c == nil {
+		_, _ = fmt.Fprintln(errOut, "Skipped alias availability check: no authenticated client available.")
+		return nil
+	}
+
+	url := validateAliasEndpoint + "?alias=" + neturl.QueryEscape(alias)
+	resp, err := c.Get(ctx, url, map[string]string{"Accept": "application/json"})
+	if err != nil {
+		_, _ = fmt.Fprintf(errOut, "Could not verify alias availability: %v\n", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	switch {
+	case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
+		return nil
+	case resp.StatusCode == http.StatusConflict:
+		return fmt.Errorf("alias %q is already in use in this tenant; create would be rejected: %s", alias, umsErrorMessage(body))
+	case resp.StatusCode == http.StatusBadRequest:
+		return fmt.Errorf("alias %q is invalid: %s", alias, umsErrorMessage(body))
+	default:
+		_, _ = fmt.Fprintf(errOut, "Could not verify alias availability (status %d): %s\n", resp.StatusCode, umsErrorMessage(body))
+		return nil
+	}
 }
 
 // resolveRestrictToUsers builds the de-duplicated, order-preserving union of the

--- a/cmd/ui_plugins/create.go
+++ b/cmd/ui_plugins/create.go
@@ -27,61 +27,28 @@ func newCreateCommand() *cobra.Command {
 		Short: "Create a UI plugin instance in the current tenant",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := loadAndValidateWorkspaceManifest(manifestFileName)
-			if err != nil {
-				return err
+			opts := createConfig{
+				private:         private,
+				restrictToUsers: restrictToUsers,
+				dryRun:          dryRun,
+				jsonOutput:      jsonOutput,
 			}
 
-			users, err := resolveRestrictToUsers(private, restrictToUsers, config.GetCurrentIdentityID)
-			if err != nil {
-				return err
-			}
-			if len(users) > 0 {
-				applyVisibilityOverride(&cfg.Manifest, users)
-			}
-
-			payload, err := json.MarshalIndent(cfg.Manifest, "", "  ")
-			if err != nil {
-				return fmt.Errorf("failed to encode plugin manifest: %w", err)
-			}
-
-			if dryRun {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(payload))
-				return nil
+			// The client is only needed on the non-dry-run path; a dry run never
+			// touches config or the network.
+			var spClient client.Client
+			if !dryRun {
+				if err := config.InitConfig(); err != nil {
+					return err
+				}
+				cliConfig, err := config.GetConfig()
+				if err != nil {
+					return err
+				}
+				spClient = client.NewSpClient(cliConfig)
 			}
 
-			if err := config.InitConfig(); err != nil {
-				return err
-			}
-			cliConfig, err := config.GetConfig()
-			if err != nil {
-				return err
-			}
-
-			spClient := client.NewSpClient(cliConfig)
-			headers := map[string]string{"Accept": "application/json"}
-
-			resp, err := spClient.Post(context.Background(), pluginInstancesEndpoint, "application/json", bytes.NewReader(payload), headers)
-			if err != nil {
-				return fmt.Errorf("failed to create plugin instance: %w", err)
-			}
-			defer resp.Body.Close()
-
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return fmt.Errorf("failed to read response: %w", err)
-			}
-
-			if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-				return mapUMSCreateError(resp.StatusCode, body, cfg.Manifest.Alias)
-			}
-
-			if jsonOutput {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
-				return nil
-			}
-
-			return renderCreateSuccess(cmd.OutOrStdout(), body, cfg.Manifest.Alias)
+			return runCreate(context.Background(), spClient, manifestFileName, cmd.OutOrStdout(), config.GetCurrentIdentityID, opts)
 		},
 	}
 
@@ -91,6 +58,67 @@ func newCreateCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the raw UMS response on success")
 
 	return cmd
+}
+
+// createConfig captures the create command's flag values.
+type createConfig struct {
+	private         bool
+	restrictToUsers []string
+	dryRun          bool
+	jsonOutput      bool
+}
+
+// runCreate loads and validates the workspace manifest at manifestPath, applies
+// visibility overrides, then either prints the payload (dry run) or POSTs it via
+// the provided client and renders the result. The client is only used on the
+// non-dry-run path, so callers may pass nil for a dry run. currentUser resolves
+// the GUID for --private and is injected for testability.
+func runCreate(ctx context.Context, c client.Client, manifestPath string, out io.Writer, currentUser func() (string, error), opts createConfig) error {
+	cfg, err := loadAndValidateWorkspaceManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	users, err := resolveRestrictToUsers(opts.private, opts.restrictToUsers, currentUser)
+	if err != nil {
+		return err
+	}
+	if len(users) > 0 {
+		applyVisibilityOverride(&cfg.Manifest, users)
+	}
+
+	payload, err := json.MarshalIndent(cfg.Manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode plugin manifest: %w", err)
+	}
+
+	if opts.dryRun {
+		_, _ = fmt.Fprintln(out, string(payload))
+		return nil
+	}
+
+	headers := map[string]string{"Accept": "application/json"}
+	resp, err := c.Post(ctx, pluginInstancesEndpoint, "application/json", bytes.NewReader(payload), headers)
+	if err != nil {
+		return fmt.Errorf("failed to create plugin instance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return mapUMSCreateError(resp.StatusCode, body, cfg.Manifest.Alias)
+	}
+
+	if opts.jsonOutput {
+		_, _ = fmt.Fprintln(out, string(body))
+		return nil
+	}
+
+	return renderCreateSuccess(out, body, cfg.Manifest.Alias)
 }
 
 // resolveRestrictToUsers builds the de-duplicated, order-preserving union of the

--- a/cmd/ui_plugins/create.go
+++ b/cmd/ui_plugins/create.go
@@ -54,7 +54,7 @@ func newCreateCommand() *cobra.Command {
 
 	cmd.Flags().BoolVar(&private, "private", false, "Restrict the plugin to the current user on every slot")
 	cmd.Flags().StringSliceVar(&restrictToUsers, "restrict-to-users", nil, "Restrict the plugin to the given user identity GUIDs on every slot (comma-separated)")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate and print the payload that would be sent without calling the backend")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate the manifest and print the payload that would be sent, without creating the plugin instance")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the raw UMS response on success")
 
 	return cmd
@@ -176,7 +176,7 @@ func mapUMSCreateError(status int, body []byte, alias string) error {
 	case http.StatusForbidden:
 		return fmt.Errorf("not authorized to create UI plugins (requires the idn:plugins-ui:create right): %s", message)
 	case http.StatusNotFound:
-		return fmt.Errorf("the UI plugins feature is not enabled for this tenant: %s", message)
+		return fmt.Errorf("the UI plugins feature is not enabled for this tenant, or the endpoint is unavailable: %s", message)
 	case http.StatusConflict:
 		return fmt.Errorf("a plugin instance with alias %q already exists for this tenant: %s", alias, message)
 	default:

--- a/cmd/ui_plugins/create.go
+++ b/cmd/ui_plugins/create.go
@@ -1,17 +1,211 @@
 package ui_plugins
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
+const pluginInstancesEndpoint = "/v2026/ui-plugins"
+
 func newCreateCommand() *cobra.Command {
-	return &cobra.Command{
+	var private bool
+	var restrictToUsers []string
+	var dryRun bool
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a UI plugin instance in the current tenant",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("`sail ui-plugins create` is not implemented yet")
+			cfg, err := loadAndValidateWorkspaceManifest(manifestFileName)
+			if err != nil {
+				return err
+			}
+
+			users, err := resolveRestrictToUsers(private, restrictToUsers, config.GetCurrentIdentityID)
+			if err != nil {
+				return err
+			}
+			if len(users) > 0 {
+				applyVisibilityOverride(&cfg.Manifest, users)
+			}
+
+			payload, err := json.MarshalIndent(cfg.Manifest, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to encode plugin manifest: %w", err)
+			}
+
+			if dryRun {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(payload))
+				return nil
+			}
+
+			if err := config.InitConfig(); err != nil {
+				return err
+			}
+			cliConfig, err := config.GetConfig()
+			if err != nil {
+				return err
+			}
+
+			spClient := client.NewSpClient(cliConfig)
+			headers := map[string]string{"Accept": "application/json"}
+
+			resp, err := spClient.Post(context.Background(), pluginInstancesEndpoint, "application/json", bytes.NewReader(payload), headers)
+			if err != nil {
+				return fmt.Errorf("failed to create plugin instance: %w", err)
+			}
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read response: %w", err)
+			}
+
+			if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+				return mapUMSCreateError(resp.StatusCode, body, cfg.Manifest.Alias)
+			}
+
+			if jsonOutput {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+				return nil
+			}
+
+			return renderCreateSuccess(cmd.OutOrStdout(), body, cfg.Manifest.Alias)
 		},
 	}
+
+	cmd.Flags().BoolVar(&private, "private", false, "Restrict the plugin to the current user on every slot")
+	cmd.Flags().StringSliceVar(&restrictToUsers, "restrict-to-users", nil, "Restrict the plugin to the given user identity GUIDs on every slot (comma-separated)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate and print the payload that would be sent without calling the backend")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the raw UMS response on success")
+
+	return cmd
+}
+
+// resolveRestrictToUsers builds the de-duplicated, order-preserving union of the
+// explicitly provided user GUIDs and, when private is set, the current user's
+// identity GUID. currentUser is injected so the resolution path is testable.
+func resolveRestrictToUsers(private bool, flagUsers []string, currentUser func() (string, error)) ([]string, error) {
+	seen := make(map[string]struct{})
+	var users []string
+
+	add := func(user string) {
+		user = strings.TrimSpace(user)
+		if user == "" {
+			return
+		}
+		if _, ok := seen[user]; ok {
+			return
+		}
+		seen[user] = struct{}{}
+		users = append(users, user)
+	}
+
+	for _, user := range flagUsers {
+		add(user)
+	}
+
+	if private {
+		id, err := currentUser()
+		if err != nil {
+			return nil, err
+		}
+		add(id)
+	}
+
+	return users, nil
+}
+
+// applyVisibilityOverride sets restrictToUsers on every slot in the manifest,
+// giving each slot its own copy of the user list.
+func applyVisibilityOverride(manifest *uiPluginManifest, users []string) {
+	for i := range manifest.Slots {
+		slotUsers := make([]string, len(users))
+		copy(slotUsers, users)
+		manifest.Slots[i].RestrictToUsers = slotUsers
+	}
+}
+
+// mapUMSCreateError translates a non-2xx UMS response into an actionable error,
+// surfacing the message returned by the backend.
+func mapUMSCreateError(status int, body []byte, alias string) error {
+	message := umsErrorMessage(body)
+
+	switch status {
+	case http.StatusBadRequest:
+		return fmt.Errorf("invalid request creating plugin instance: %s", message)
+	case http.StatusForbidden:
+		return fmt.Errorf("not authorized to create UI plugins (requires the idn:plugins-ui:create right): %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("the UI plugins feature is not enabled for this tenant: %s", message)
+	case http.StatusConflict:
+		return fmt.Errorf("a plugin instance with alias %q already exists for this tenant: %s", alias, message)
+	default:
+		return fmt.Errorf("failed to create plugin instance (status %d): %s", status, message)
+	}
+}
+
+// umsErrorMessage extracts a human-readable message from a UMS error body,
+// which follows the NestJS shape {"statusCode":N,"message":string|[]string,"error":string}.
+// It falls back to the raw body when the shape is unrecognized.
+func umsErrorMessage(body []byte) string {
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return "no response body"
+	}
+
+	var parsed struct {
+		Message json.RawMessage `json:"message"`
+		Error   string          `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil {
+		if len(parsed.Message) > 0 {
+			var single string
+			if json.Unmarshal(parsed.Message, &single) == nil && strings.TrimSpace(single) != "" {
+				return single
+			}
+			var many []string
+			if json.Unmarshal(parsed.Message, &many) == nil && len(many) > 0 {
+				return strings.Join(many, "; ")
+			}
+		}
+		if parsed.Error != "" {
+			return parsed.Error
+		}
+	}
+
+	return trimmed
+}
+
+// renderCreateSuccess prints a human-readable confirmation of the created instance.
+func renderCreateSuccess(w io.Writer, body []byte, fallbackAlias string) error {
+	var created struct {
+		PluginInstanceID string `json:"pluginInstanceId"`
+		Alias            string `json:"alias"`
+	}
+	_ = json.Unmarshal(body, &created)
+
+	alias := created.Alias
+	if alias == "" {
+		alias = fallbackAlias
+	}
+
+	if created.PluginInstanceID != "" {
+		_, _ = fmt.Fprintf(w, "Created plugin instance %s (alias: %s)\n", created.PluginInstanceID, alias)
+	} else {
+		_, _ = fmt.Fprintf(w, "Created plugin instance (alias: %s)\n", alias)
+	}
+
+	return nil
 }

--- a/cmd/ui_plugins/create.go
+++ b/cmd/ui_plugins/create.go
@@ -23,7 +23,21 @@ var createHelp string
 const (
 	pluginInstancesEndpoint = "/v2026/ui-plugins"
 	validateAliasEndpoint   = pluginInstancesEndpoint + "/validate-alias"
+
+	// experimentalHeader must be sent on ui-plugins requests while the routes are
+	// in a preview API lifecycle state (limited-preview / public-preview).
+	experimentalHeader = "X-SailPoint-Experimental"
 )
+
+// uiPluginRequestHeaders returns the headers required on every external
+// ui-plugins request: JSON accept plus the experimental opt-in header the
+// preview-state routes require.
+func uiPluginRequestHeaders() map[string]string {
+	return map[string]string{
+		"Accept":           "application/json",
+		experimentalHeader: "true",
+	}
+}
 
 func newCreateCommand() *cobra.Command {
 	var private bool
@@ -116,8 +130,7 @@ func runCreate(ctx context.Context, c client.Client, manifestPath string, out io
 		return checkAliasAvailability(ctx, c, errOut, cfg.Manifest.Alias)
 	}
 
-	headers := map[string]string{"Accept": "application/json"}
-	resp, err := c.Post(ctx, pluginInstancesEndpoint, "application/json", bytes.NewReader(payload), headers)
+	resp, err := c.Post(ctx, pluginInstancesEndpoint, "application/json", bytes.NewReader(payload), uiPluginRequestHeaders())
 	if err != nil {
 		return fmt.Errorf("failed to create plugin instance: %w", err)
 	}
@@ -154,7 +167,7 @@ func checkAliasAvailability(ctx context.Context, c client.Client, errOut io.Writ
 	}
 
 	url := validateAliasEndpoint + "?alias=" + neturl.QueryEscape(alias)
-	resp, err := c.Get(ctx, url, map[string]string{"Accept": "application/json"})
+	resp, err := c.Get(ctx, url, uiPluginRequestHeaders())
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "Could not verify alias availability: %v\n", err)
 		return nil

--- a/cmd/ui_plugins/create.md
+++ b/cmd/ui_plugins/create.md
@@ -1,0 +1,45 @@
+==Long==
+# Create
+
+Registers a UI plugin instance in the current tenant from the workspace manifest at `./sp-ui-plugin.json`.
+
+The manifest is validated locally first (the same structural checks as `validate-manifest`); only the `manifest` section is sent to UMS — the local `build` section is never transmitted. The workspace alias becomes the instance identifier, and an alias already in use in the tenant is reported as a conflict.
+
+## Visibility overrides
+
+Both overrides apply per slot and replace any `restrictToUsers` declared in the manifest:
+
+- `--restrict-to-users` adds the given user identity GUIDs to every slot.
+- `--private` adds your own identity (resolved from the active token) to every slot.
+
+When both are supplied, each slot's `restrictToUsers` is the de-duplicated union of your identity and the supplied GUIDs.
+
+## Dry run
+
+`--dry-run` validates the manifest, applies any overrides, and prints the exact payload that would be sent — without creating the instance. It also performs a read-only alias availability check against the tenant when possible; an alias that is already taken or invalid is reported, while an inconclusive check (e.g. connectivity or access) is noted without failing.
+
+## Output
+
+On success a short confirmation with the new plugin instance ID and alias is printed. Use `--json` to print the raw UMS response instead.
+====
+
+==Example==
+
+```bash
+# Create from ./sp-ui-plugin.json
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins create
+
+# Preview the payload (and check alias availability) without creating
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins create --dry-run
+
+# Restrict the plugin to yourself on every slot
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins create --private
+
+# Restrict the plugin to specific users on every slot
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins create --restrict-to-users 2c9180...a1,2c9180...b2
+
+# Print the raw UMS response on success
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins create --json
+```
+
+====

--- a/cmd/ui_plugins/create_test.go
+++ b/cmd/ui_plugins/create_test.go
@@ -2,11 +2,244 @@ package ui_plugins
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"io"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
 )
+
+const testManifestJSON = `{
+  "version": 1,
+  "manifest": {
+    "alias": "access-request-plugin",
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}]
+  }
+}`
+
+// fakeClient is a test double for client.Client that returns a canned response
+// from Post and records the request it received. Other methods are unused.
+type fakeClient struct {
+	status    int
+	body      string
+	postErr   error
+	postCalls int
+	gotURL    string
+	gotBody   []byte
+}
+
+var _ client.Client = (*fakeClient)(nil)
+
+func (f *fakeClient) Post(ctx context.Context, url string, contentType string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	f.postCalls++
+	f.gotURL = url
+	if body != nil {
+		f.gotBody, _ = io.ReadAll(body)
+	}
+	if f.postErr != nil {
+		return nil, f.postErr
+	}
+	return &http.Response{
+		StatusCode: f.status,
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+	}, nil
+}
+
+func (f *fakeClient) Get(ctx context.Context, url string, headers map[string]string) (*http.Response, error) {
+	return nil, errors.New("unused")
+}
+
+func (f *fakeClient) Delete(ctx context.Context, url string, params map[string]string, headers map[string]string) (*http.Response, error) {
+	return nil, errors.New("unused")
+}
+
+func (f *fakeClient) Put(ctx context.Context, url string, contentType string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	return nil, errors.New("unused")
+}
+
+func (f *fakeClient) Patch(ctx context.Context, url string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	return nil, errors.New("unused")
+}
+
+func tempManifestPath(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), manifestFileName)
+	writeManifestAtPath(t, path, content)
+	return path
+}
+
+func stubCurrentUser() (string, error) { return "current-user-guid", nil }
+
+// --- runCreate: end-to-end HTTP path via fake client ---
+
+func TestRunCreate_SuccessHumanOutput(t *testing.T) {
+	fc := &fakeClient{status: http.StatusCreated, body: `{"pluginInstanceId":"pi-123","alias":"access-request-plugin"}`}
+	var out bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fc.postCalls != 1 {
+		t.Fatalf("expected exactly one Post, got %d", fc.postCalls)
+	}
+	if fc.gotURL != pluginInstancesEndpoint {
+		t.Fatalf("expected POST to %s, got %s", pluginInstancesEndpoint, fc.gotURL)
+	}
+	if !strings.Contains(string(fc.gotBody), "access-request-plugin") {
+		t.Fatalf("expected manifest alias in request body, got: %s", fc.gotBody)
+	}
+	got := out.String()
+	if !strings.Contains(got, "pi-123") || !strings.Contains(got, "access-request-plugin") {
+		t.Fatalf("expected success summary with id and alias, got: %s", got)
+	}
+}
+
+func TestRunCreate_JSONPassthrough(t *testing.T) {
+	respBody := `{"pluginInstanceId":"pi-123","alias":"access-request-plugin","slots":[]}`
+	fc := &fakeClient{status: http.StatusCreated, body: respBody}
+	var out bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{jsonOutput: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.TrimSpace(out.String()) != respBody {
+		t.Fatalf("expected raw response body passthrough, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "Created plugin instance") {
+		t.Fatalf("--json output should not include the human summary, got: %s", out.String())
+	}
+}
+
+func TestRunCreate_ErrorMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{name: "bad request", status: 400, body: `{"message":"alias must be 3-63 chars"}`, want: "invalid request"},
+		{name: "forbidden", status: 403, body: `{"message":"Forbidden"}`, want: "not authorized"},
+		{name: "not found", status: 404, body: `{"message":"Not Found"}`, want: "not enabled"},
+		{name: "conflict", status: 409, body: `{"message":"alias 'access-request-plugin' already exists for this tenant"}`, want: "already exists"},
+		{name: "server error", status: 500, body: `{"message":"boom"}`, want: "status 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := &fakeClient{status: tt.status, body: tt.body}
+			var out bytes.Buffer
+
+			err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error to contain %q, got: %v", tt.want, err)
+			}
+			if fc.postCalls != 1 {
+				t.Fatalf("expected the request to be sent, got %d Post calls", fc.postCalls)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("expected no stdout on error, got: %s", out.String())
+			}
+		})
+	}
+}
+
+func TestRunCreate_TransportError(t *testing.T) {
+	fc := &fakeClient{postErr: errors.New("connection refused")}
+	var out bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{})
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if !strings.Contains(err.Error(), "failed to create plugin instance") {
+		t.Fatalf("expected wrapped transport error, got: %v", err)
+	}
+}
+
+func TestRunCreate_DryRunSkipsClient(t *testing.T) {
+	fc := &fakeClient{status: http.StatusCreated, body: `{}`}
+	var out bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{dryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fc.postCalls != 0 {
+		t.Fatal("dry run must not call the client")
+	}
+	if !strings.Contains(out.String(), `"alias": "access-request-plugin"`) {
+		t.Fatalf("expected payload printed on dry run, got: %s", out.String())
+	}
+}
+
+func TestRunCreate_DryRunAppliesOverrides(t *testing.T) {
+	fc := &fakeClient{}
+	var out bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser,
+		createConfig{dryRun: true, private: true, restrictToUsers: []string{"user-a"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "restrictToUsers") || !strings.Contains(got, "user-a") || !strings.Contains(got, "current-user-guid") {
+		t.Fatalf("expected union of override users in payload, got: %s", got)
+	}
+}
+
+func TestRunCreate_InvalidManifestSkipsPost(t *testing.T) {
+	invalid := `{
+  "version": 1,
+  "manifest": {
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}]
+  }
+}`
+	fc := &fakeClient{status: http.StatusCreated, body: `{}`}
+	var out bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, invalid), &out, stubCurrentUser, createConfig{})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "manifest.alias is required") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+	if fc.postCalls != 0 {
+		t.Fatal("invalid manifest must fail before any backend call")
+	}
+}
+
+func TestRunCreate_PrivateResolverErrorSkipsPost(t *testing.T) {
+	wantErr := errors.New("no user context")
+	fc := &fakeClient{status: http.StatusCreated, body: `{}`}
+	var out bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out,
+		func() (string, error) { return "", wantErr }, createConfig{private: true})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected current-user error to propagate, got: %v", err)
+	}
+	if fc.postCalls != 0 {
+		t.Fatal("resolver failure must fail before any backend call")
+	}
+}
+
+// --- pure helpers ---
 
 func TestResolveRestrictToUsers(t *testing.T) {
 	currentUser := func() (string, error) { return "current-user-guid", nil }
@@ -166,6 +399,8 @@ func TestRenderCreateSuccess(t *testing.T) {
 	})
 }
 
+// --- command wiring (cobra + experimental gate + flags), hermetic via dry run ---
+
 func TestCreateCommand_DryRunPrintsPayloadWithoutBuildSection(t *testing.T) {
 	t.Setenv(experimentalUIPluginsEnvVar, "1")
 	cwd := t.TempDir()
@@ -200,40 +435,7 @@ func TestCreateCommand_DryRunPrintsPayloadWithoutBuildSection(t *testing.T) {
 	}
 }
 
-func TestCreateCommand_DryRunAppliesRestrictToUsers(t *testing.T) {
-	t.Setenv(experimentalUIPluginsEnvVar, "1")
-	cwd := t.TempDir()
-	writeManifestAtPath(t, filepath.Join(cwd, manifestFileName), `{
-  "version": 1,
-  "manifest": {
-    "alias": "access-request-plugin",
-    "name": {"en-US": "Access Request"},
-    "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}, {"slotId": "side-panel"}]
-  }
-}`)
-
-	restore := chdirForTest(t, cwd)
-	defer restore()
-
-	cmd := NewUIPluginsCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"create", "--dry-run", "--restrict-to-users", "user-a,user-b"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("expected dry-run to succeed, got: %v", err)
-	}
-
-	output := out.String()
-	if strings.Count(output, "restrictToUsers") != 2 {
-		t.Fatalf("expected restrictToUsers on both slots, got: %s", output)
-	}
-	if !strings.Contains(output, "user-a") || !strings.Contains(output, "user-b") {
-		t.Fatalf("expected override users in payload, got: %s", output)
-	}
-}
-
-func TestCreateCommand_InvalidManifestFailsBeforeNetwork(t *testing.T) {
+func TestCreateCommand_InvalidManifestSurfacesValidationError(t *testing.T) {
 	t.Setenv(experimentalUIPluginsEnvVar, "1")
 	cwd := t.TempDir()
 	writeManifestAtPath(t, filepath.Join(cwd, manifestFileName), `{
@@ -249,13 +451,14 @@ func TestCreateCommand_InvalidManifestFailsBeforeNetwork(t *testing.T) {
 	defer restore()
 
 	cmd := NewUIPluginsCommand()
-	cmd.SetArgs([]string{"create"})
+	// --dry-run keeps this hermetic (no config/auth needed); validation runs first regardless.
+	cmd.SetArgs([]string{"create", "--dry-run"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected create to fail on an invalid manifest")
 	}
 	if !strings.Contains(err.Error(), "manifest.alias is required") {
-		t.Fatalf("expected validation error before any network call, got: %v", err)
+		t.Fatalf("expected validation error, got: %v", err)
 	}
 }
 

--- a/cmd/ui_plugins/create_test.go
+++ b/cmd/ui_plugins/create_test.go
@@ -1,0 +1,272 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveRestrictToUsers(t *testing.T) {
+	currentUser := func() (string, error) { return "current-user-guid", nil }
+
+	tests := []struct {
+		name      string
+		private   bool
+		flagUsers []string
+		want      []string
+	}{
+		{name: "no flags", want: nil},
+		{name: "flag users only", flagUsers: []string{"user-a", "user-b"}, want: []string{"user-a", "user-b"}},
+		{name: "private only", private: true, want: []string{"current-user-guid"}},
+		{
+			name:      "union of both",
+			private:   true,
+			flagUsers: []string{"user-a", "user-b"},
+			want:      []string{"user-a", "user-b", "current-user-guid"},
+		},
+		{
+			name:      "dedup current user already in list",
+			private:   true,
+			flagUsers: []string{"current-user-guid", "user-b"},
+			want:      []string{"current-user-guid", "user-b"},
+		},
+		{
+			name:      "dedup and trim flag users",
+			flagUsers: []string{" user-a ", "user-a", ""},
+			want:      []string{"user-a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRestrictToUsers(tt.private, tt.flagUsers, currentUser)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStrings(got, tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveRestrictToUsers_CurrentUserError(t *testing.T) {
+	wantErr := errors.New("no user context")
+	currentUser := func() (string, error) { return "", wantErr }
+
+	_, err := resolveRestrictToUsers(true, []string{"user-a"}, currentUser)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected current-user error to propagate, got: %v", err)
+	}
+}
+
+func TestResolveRestrictToUsers_CurrentUserNotCalledWithoutPrivate(t *testing.T) {
+	called := false
+	currentUser := func() (string, error) { called = true; return "x", nil }
+
+	if _, err := resolveRestrictToUsers(false, []string{"user-a"}, currentUser); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("current user resolver should not be called when --private is unset")
+	}
+}
+
+func TestApplyVisibilityOverride(t *testing.T) {
+	manifest := uiPluginManifest{
+		Slots: []uiPluginSlot{
+			{SlotID: "full-page"},
+			{SlotID: "side-panel", RestrictToUsers: []string{"existing"}},
+		},
+	}
+
+	users := []string{"user-a", "user-b"}
+	applyVisibilityOverride(&manifest, users)
+
+	for i, slot := range manifest.Slots {
+		if !equalStrings(slot.RestrictToUsers, users) {
+			t.Fatalf("slot %d: expected %v, got %v", i, users, slot.RestrictToUsers)
+		}
+	}
+
+	// Each slot must own an independent copy.
+	manifest.Slots[0].RestrictToUsers[0] = "mutated"
+	if manifest.Slots[1].RestrictToUsers[0] == "mutated" {
+		t.Fatal("slots share the same restrictToUsers backing array")
+	}
+}
+
+func TestMapUMSCreateError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{name: "bad request", status: 400, body: `{"message":"alias must be 3-63 chars"}`, want: "invalid request"},
+		{name: "forbidden", status: 403, body: `{"message":"Forbidden"}`, want: "not authorized"},
+		{name: "not found", status: 404, body: `{"message":"Not Found"}`, want: "not enabled"},
+		{name: "conflict", status: 409, body: `{"message":"alias 'my-plugin' already exists for this tenant"}`, want: "already exists"},
+		{name: "server error", status: 500, body: `{"message":"boom"}`, want: "status 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mapUMSCreateError(tt.status, []byte(tt.body), "my-plugin")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error to contain %q, got: %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestUMSErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "string message", body: `{"statusCode":400,"message":"bad alias","error":"Bad Request"}`, want: "bad alias"},
+		{name: "array message", body: `{"message":["alias too short","name required"]}`, want: "alias too short; name required"},
+		{name: "error fallback", body: `{"error":"Conflict"}`, want: "Conflict"},
+		{name: "plain body", body: `something failed`, want: "something failed"},
+		{name: "empty body", body: ``, want: "no response body"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := umsErrorMessage([]byte(tt.body)); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRenderCreateSuccess(t *testing.T) {
+	t.Run("with id and alias", func(t *testing.T) {
+		var out bytes.Buffer
+		_ = renderCreateSuccess(&out, []byte(`{"pluginInstanceId":"abc123","alias":"my-plugin"}`), "fallback")
+		got := out.String()
+		if !strings.Contains(got, "abc123") || !strings.Contains(got, "my-plugin") {
+			t.Fatalf("expected id and alias in output, got: %s", got)
+		}
+	})
+
+	t.Run("falls back to manifest alias", func(t *testing.T) {
+		var out bytes.Buffer
+		_ = renderCreateSuccess(&out, []byte(`{}`), "fallback-alias")
+		if !strings.Contains(out.String(), "fallback-alias") {
+			t.Fatalf("expected fallback alias, got: %s", out.String())
+		}
+	})
+}
+
+func TestCreateCommand_DryRunPrintsPayloadWithoutBuildSection(t *testing.T) {
+	t.Setenv(experimentalUIPluginsEnvVar, "1")
+	cwd := t.TempDir()
+	writeManifestAtPath(t, filepath.Join(cwd, manifestFileName), `{
+  "version": 1,
+  "manifest": {
+    "alias": "access-request-plugin",
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}]
+  },
+  "build": {"outDir": "dist", "port": 8080}
+}`)
+
+	restore := chdirForTest(t, cwd)
+	defer restore()
+
+	cmd := NewUIPluginsCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"create", "--dry-run"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected dry-run to succeed, got: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, `"alias": "access-request-plugin"`) {
+		t.Fatalf("expected manifest alias in payload, got: %s", output)
+	}
+	if strings.Contains(output, "outDir") || strings.Contains(output, "8080") {
+		t.Fatalf("local build section must not be in the payload, got: %s", output)
+	}
+}
+
+func TestCreateCommand_DryRunAppliesRestrictToUsers(t *testing.T) {
+	t.Setenv(experimentalUIPluginsEnvVar, "1")
+	cwd := t.TempDir()
+	writeManifestAtPath(t, filepath.Join(cwd, manifestFileName), `{
+  "version": 1,
+  "manifest": {
+    "alias": "access-request-plugin",
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}, {"slotId": "side-panel"}]
+  }
+}`)
+
+	restore := chdirForTest(t, cwd)
+	defer restore()
+
+	cmd := NewUIPluginsCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"create", "--dry-run", "--restrict-to-users", "user-a,user-b"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected dry-run to succeed, got: %v", err)
+	}
+
+	output := out.String()
+	if strings.Count(output, "restrictToUsers") != 2 {
+		t.Fatalf("expected restrictToUsers on both slots, got: %s", output)
+	}
+	if !strings.Contains(output, "user-a") || !strings.Contains(output, "user-b") {
+		t.Fatalf("expected override users in payload, got: %s", output)
+	}
+}
+
+func TestCreateCommand_InvalidManifestFailsBeforeNetwork(t *testing.T) {
+	t.Setenv(experimentalUIPluginsEnvVar, "1")
+	cwd := t.TempDir()
+	writeManifestAtPath(t, filepath.Join(cwd, manifestFileName), `{
+  "version": 1,
+  "manifest": {
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}]
+  }
+}`)
+
+	restore := chdirForTest(t, cwd)
+	defer restore()
+
+	cmd := NewUIPluginsCommand()
+	cmd.SetArgs([]string{"create"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected create to fail on an invalid manifest")
+	}
+	if !strings.Contains(err.Error(), "manifest.alias is required") {
+		t.Fatalf("expected validation error before any network call, got: %v", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/ui_plugins/create_test.go
+++ b/cmd/ui_plugins/create_test.go
@@ -39,19 +39,21 @@ const manifestWithBuildJSON = `{
 // response. The remaining methods are unused.
 type fakeClient struct {
 	// Post (create)
-	status    int
-	body      string
-	postErr   error
-	postCalls int
-	gotURL    string
-	gotBody   []byte
+	status         int
+	body           string
+	postErr        error
+	postCalls      int
+	gotURL         string
+	gotBody        []byte
+	gotPostHeaders map[string]string
 
 	// Get (validate-alias)
-	getStatus int
-	getBody   string
-	getErr    error
-	getCalls  int
-	gotGetURL string
+	getStatus     int
+	getBody       string
+	getErr        error
+	getCalls      int
+	gotGetURL     string
+	gotGetHeaders map[string]string
 }
 
 var _ client.Client = (*fakeClient)(nil)
@@ -59,6 +61,7 @@ var _ client.Client = (*fakeClient)(nil)
 func (f *fakeClient) Post(ctx context.Context, url string, contentType string, body io.Reader, headers map[string]string) (*http.Response, error) {
 	f.postCalls++
 	f.gotURL = url
+	f.gotPostHeaders = headers
 	if body != nil {
 		f.gotBody, _ = io.ReadAll(body)
 	}
@@ -74,6 +77,7 @@ func (f *fakeClient) Post(ctx context.Context, url string, contentType string, b
 func (f *fakeClient) Get(ctx context.Context, url string, headers map[string]string) (*http.Response, error) {
 	f.getCalls++
 	f.gotGetURL = url
+	f.gotGetHeaders = headers
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
@@ -123,6 +127,9 @@ func TestRunCreate_SuccessHumanOutput(t *testing.T) {
 	}
 	if !strings.Contains(string(fc.gotBody), "access-request-plugin") {
 		t.Fatalf("expected manifest alias in request body, got: %s", fc.gotBody)
+	}
+	if fc.gotPostHeaders[experimentalHeader] != "true" {
+		t.Fatalf("expected %s header on create, got: %v", experimentalHeader, fc.gotPostHeaders)
 	}
 	got := out.String()
 	if !strings.Contains(got, "pi-123") || !strings.Contains(got, "access-request-plugin") {
@@ -254,6 +261,9 @@ func TestRunCreate_DryRunPrintsPayloadAndChecksAlias(t *testing.T) {
 	}
 	if !strings.Contains(fc.gotGetURL, validateAliasEndpoint) || !strings.Contains(fc.gotGetURL, "alias=access-request-plugin") {
 		t.Fatalf("unexpected validate-alias URL: %s", fc.gotGetURL)
+	}
+	if fc.gotGetHeaders[experimentalHeader] != "true" {
+		t.Fatalf("expected %s header on alias check, got: %v", experimentalHeader, fc.gotGetHeaders)
 	}
 	if !strings.Contains(out.String(), `"alias": "access-request-plugin"`) {
 		t.Fatalf("expected payload on stdout, got: %s", out.String())
@@ -554,6 +564,16 @@ func TestCreateCommand_InvalidManifestSurfacesValidationError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "manifest.alias is required") {
 		t.Fatalf("expected validation error, got: %v", err)
+	}
+}
+
+func TestUIPluginRequestHeaders(t *testing.T) {
+	h := uiPluginRequestHeaders()
+	if h[experimentalHeader] != "true" {
+		t.Fatalf("expected %s: true, got: %v", experimentalHeader, h)
+	}
+	if h["Accept"] != "application/json" {
+		t.Fatalf("expected Accept: application/json, got: %v", h)
 	}
 }
 

--- a/cmd/ui_plugins/create_test.go
+++ b/cmd/ui_plugins/create_test.go
@@ -19,7 +19,10 @@ const testManifestJSON = `{
     "alias": "access-request-plugin",
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   }
 }`
 
@@ -29,7 +32,10 @@ const manifestWithBuildJSON = `{
     "alias": "access-request-plugin",
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   },
   "build": {"outDir": "dist", "port": 8080}
 }`
@@ -361,7 +367,10 @@ func TestRunCreate_DryRunAppliesOverrides(t *testing.T) {
     "alias": "access-request-plugin",
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}, {"slotId": "side-panel"}]
+    "slots": [{"slotId": "full-page"}, {"slotId": "side-panel"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   }
 }`
 	err := runCreate(context.Background(), fc, tempManifestPath(t, manifest), &out, &errOut, stubCurrentUser,

--- a/cmd/ui_plugins/create_test.go
+++ b/cmd/ui_plugins/create_test.go
@@ -23,15 +23,35 @@ const testManifestJSON = `{
   }
 }`
 
-// fakeClient is a test double for client.Client that returns a canned response
-// from Post and records the request it received. Other methods are unused.
+const manifestWithBuildJSON = `{
+  "version": 1,
+  "manifest": {
+    "alias": "access-request-plugin",
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}]
+  },
+  "build": {"outDir": "dist", "port": 8080}
+}`
+
+// fakeClient is a test double for client.Client. Post backs the create path and Get
+// backs the dry-run validate-alias check; each records its call and returns a canned
+// response. The remaining methods are unused.
 type fakeClient struct {
+	// Post (create)
 	status    int
 	body      string
 	postErr   error
 	postCalls int
 	gotURL    string
 	gotBody   []byte
+
+	// Get (validate-alias)
+	getStatus int
+	getBody   string
+	getErr    error
+	getCalls  int
+	gotGetURL string
 }
 
 var _ client.Client = (*fakeClient)(nil)
@@ -52,7 +72,15 @@ func (f *fakeClient) Post(ctx context.Context, url string, contentType string, b
 }
 
 func (f *fakeClient) Get(ctx context.Context, url string, headers map[string]string) (*http.Response, error) {
-	return nil, errors.New("unused")
+	f.getCalls++
+	f.gotGetURL = url
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return &http.Response{
+		StatusCode: f.getStatus,
+		Body:       io.NopCloser(strings.NewReader(f.getBody)),
+	}, nil
 }
 
 func (f *fakeClient) Delete(ctx context.Context, url string, params map[string]string, headers map[string]string) (*http.Response, error) {
@@ -76,13 +104,13 @@ func tempManifestPath(t *testing.T, content string) string {
 
 func stubCurrentUser() (string, error) { return "current-user-guid", nil }
 
-// --- runCreate: end-to-end HTTP path via fake client ---
+// --- create path (POST) via fake client ---
 
 func TestRunCreate_SuccessHumanOutput(t *testing.T) {
 	fc := &fakeClient{status: http.StatusCreated, body: `{"pluginInstanceId":"pi-123","alias":"access-request-plugin"}`}
 	var out bytes.Buffer
 
-	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{})
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, io.Discard, stubCurrentUser, createConfig{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -107,7 +135,7 @@ func TestRunCreate_JSONPassthrough(t *testing.T) {
 	fc := &fakeClient{status: http.StatusCreated, body: respBody}
 	var out bytes.Buffer
 
-	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{jsonOutput: true})
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, io.Discard, stubCurrentUser, createConfig{jsonOutput: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -139,7 +167,7 @@ func TestRunCreate_ErrorMapping(t *testing.T) {
 			fc := &fakeClient{status: tt.status, body: tt.body}
 			var out bytes.Buffer
 
-			err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{})
+			err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, io.Discard, stubCurrentUser, createConfig{})
 			if err == nil {
 				t.Fatal("expected an error")
 			}
@@ -160,43 +188,12 @@ func TestRunCreate_TransportError(t *testing.T) {
 	fc := &fakeClient{postErr: errors.New("connection refused")}
 	var out bytes.Buffer
 
-	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{})
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, io.Discard, stubCurrentUser, createConfig{})
 	if err == nil {
 		t.Fatal("expected a transport error")
 	}
 	if !strings.Contains(err.Error(), "failed to create plugin instance") {
 		t.Fatalf("expected wrapped transport error, got: %v", err)
-	}
-}
-
-func TestRunCreate_DryRunSkipsClient(t *testing.T) {
-	fc := &fakeClient{status: http.StatusCreated, body: `{}`}
-	var out bytes.Buffer
-
-	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser, createConfig{dryRun: true})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if fc.postCalls != 0 {
-		t.Fatal("dry run must not call the client")
-	}
-	if !strings.Contains(out.String(), `"alias": "access-request-plugin"`) {
-		t.Fatalf("expected payload printed on dry run, got: %s", out.String())
-	}
-}
-
-func TestRunCreate_DryRunAppliesOverrides(t *testing.T) {
-	fc := &fakeClient{}
-	var out bytes.Buffer
-
-	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, stubCurrentUser,
-		createConfig{dryRun: true, private: true, restrictToUsers: []string{"user-a"}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	got := out.String()
-	if !strings.Contains(got, "restrictToUsers") || !strings.Contains(got, "user-a") || !strings.Contains(got, "current-user-guid") {
-		t.Fatalf("expected union of override users in payload, got: %s", got)
 	}
 }
 
@@ -212,14 +209,14 @@ func TestRunCreate_InvalidManifestSkipsPost(t *testing.T) {
 	fc := &fakeClient{status: http.StatusCreated, body: `{}`}
 	var out bytes.Buffer
 
-	err := runCreate(context.Background(), fc, tempManifestPath(t, invalid), &out, stubCurrentUser, createConfig{})
+	err := runCreate(context.Background(), fc, tempManifestPath(t, invalid), &out, io.Discard, stubCurrentUser, createConfig{})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
 	if !strings.Contains(err.Error(), "manifest.alias is required") {
 		t.Fatalf("expected validation error, got: %v", err)
 	}
-	if fc.postCalls != 0 {
+	if fc.postCalls != 0 || fc.getCalls != 0 {
 		t.Fatal("invalid manifest must fail before any backend call")
 	}
 }
@@ -229,13 +226,145 @@ func TestRunCreate_PrivateResolverErrorSkipsPost(t *testing.T) {
 	fc := &fakeClient{status: http.StatusCreated, body: `{}`}
 	var out bytes.Buffer
 
-	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out,
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, io.Discard,
 		func() (string, error) { return "", wantErr }, createConfig{private: true})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("expected current-user error to propagate, got: %v", err)
 	}
 	if fc.postCalls != 0 {
 		t.Fatal("resolver failure must fail before any backend call")
+	}
+}
+
+// --- dry-run path: payload preview + best-effort alias availability check ---
+
+func TestRunCreate_DryRunPrintsPayloadAndChecksAlias(t *testing.T) {
+	fc := &fakeClient{getStatus: http.StatusOK}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, manifestWithBuildJSON), &out, &errOut, stubCurrentUser, createConfig{dryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fc.postCalls != 0 {
+		t.Fatal("dry run must not POST")
+	}
+	if fc.getCalls != 1 {
+		t.Fatalf("expected one alias check GET, got %d", fc.getCalls)
+	}
+	if !strings.Contains(fc.gotGetURL, validateAliasEndpoint) || !strings.Contains(fc.gotGetURL, "alias=access-request-plugin") {
+		t.Fatalf("unexpected validate-alias URL: %s", fc.gotGetURL)
+	}
+	if !strings.Contains(out.String(), `"alias": "access-request-plugin"`) {
+		t.Fatalf("expected payload on stdout, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "outDir") || strings.Contains(out.String(), "8080") {
+		t.Fatalf("local build section must not be in the payload, got: %s", out.String())
+	}
+	// Available => clean stdout (payload only), nothing on stderr.
+	if errOut.Len() != 0 {
+		t.Fatalf("expected no advisory output when alias is available, got: %s", errOut.String())
+	}
+}
+
+func TestRunCreate_DryRunAliasTaken(t *testing.T) {
+	fc := &fakeClient{getStatus: http.StatusConflict, getBody: `{"message":"alias 'access-request-plugin' already exists for this tenant"}`}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, &errOut, stubCurrentUser, createConfig{dryRun: true})
+	if err == nil {
+		t.Fatal("expected a definitive error when the alias is taken")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("expected alias-taken error, got: %v", err)
+	}
+	if !strings.Contains(out.String(), `"alias": "access-request-plugin"`) {
+		t.Fatalf("payload should still print before the alias error, got: %s", out.String())
+	}
+	if fc.postCalls != 0 {
+		t.Fatal("dry run must not POST")
+	}
+}
+
+func TestRunCreate_DryRunAliasInvalid(t *testing.T) {
+	fc := &fakeClient{getStatus: http.StatusBadRequest, getBody: `{"message":"alias must be 3-63 chars"}`}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, &errOut, stubCurrentUser, createConfig{dryRun: true})
+	if err == nil || !strings.Contains(err.Error(), "is invalid") {
+		t.Fatalf("expected alias-invalid error, got: %v", err)
+	}
+}
+
+func TestRunCreate_DryRunAliasUnverifiableIsNonFatal(t *testing.T) {
+	// 401 (private route / external token) is the current real-world case; treat as advisory.
+	fc := &fakeClient{getStatus: http.StatusUnauthorized, getBody: `{"message":"private route cannot be accessed using external token"}`}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, &errOut, stubCurrentUser, createConfig{dryRun: true})
+	if err != nil {
+		t.Fatalf("inconclusive check must be non-fatal, got: %v", err)
+	}
+	if !strings.Contains(out.String(), `"alias": "access-request-plugin"`) {
+		t.Fatalf("payload should still print, got: %s", out.String())
+	}
+	if !strings.Contains(errOut.String(), "Could not verify alias availability") {
+		t.Fatalf("expected advisory note on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestRunCreate_DryRunAliasTransportErrorIsNonFatal(t *testing.T) {
+	fc := &fakeClient{getErr: errors.New("connection refused")}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, tempManifestPath(t, testManifestJSON), &out, &errOut, stubCurrentUser, createConfig{dryRun: true})
+	if err != nil {
+		t.Fatalf("transport error during alias check must be non-fatal, got: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "Could not verify alias availability") {
+		t.Fatalf("expected advisory note on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestRunCreate_DryRunNoClientSkipsCheck(t *testing.T) {
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), nil, tempManifestPath(t, testManifestJSON), &out, &errOut, stubCurrentUser, createConfig{dryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), `"alias": "access-request-plugin"`) {
+		t.Fatalf("payload should still print without a client, got: %s", out.String())
+	}
+	if !strings.Contains(errOut.String(), "Skipped alias availability check") {
+		t.Fatalf("expected skip note on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestRunCreate_DryRunAppliesOverrides(t *testing.T) {
+	fc := &fakeClient{getStatus: http.StatusOK}
+	var out, errOut bytes.Buffer
+
+	manifest := `{
+  "version": 1,
+  "manifest": {
+    "alias": "access-request-plugin",
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}, {"slotId": "side-panel"}]
+  }
+}`
+	err := runCreate(context.Background(), fc, tempManifestPath(t, manifest), &out, &errOut, stubCurrentUser,
+		createConfig{dryRun: true, private: true, restrictToUsers: []string{"user-a"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	if strings.Count(got, "restrictToUsers") != 2 {
+		t.Fatalf("expected restrictToUsers on both slots, got: %s", got)
+	}
+	if !strings.Contains(got, "user-a") || !strings.Contains(got, "current-user-guid") {
+		t.Fatalf("expected union of override users in payload, got: %s", got)
 	}
 }
 
@@ -399,41 +528,8 @@ func TestRenderCreateSuccess(t *testing.T) {
 	})
 }
 
-// --- command wiring (cobra + experimental gate + flags), hermetic via dry run ---
-
-func TestCreateCommand_DryRunPrintsPayloadWithoutBuildSection(t *testing.T) {
-	t.Setenv(experimentalUIPluginsEnvVar, "1")
-	cwd := t.TempDir()
-	writeManifestAtPath(t, filepath.Join(cwd, manifestFileName), `{
-  "version": 1,
-  "manifest": {
-    "alias": "access-request-plugin",
-    "name": {"en-US": "Access Request"},
-    "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
-  },
-  "build": {"outDir": "dist", "port": 8080}
-}`)
-
-	restore := chdirForTest(t, cwd)
-	defer restore()
-
-	cmd := NewUIPluginsCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"create", "--dry-run"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("expected dry-run to succeed, got: %v", err)
-	}
-
-	output := out.String()
-	if !strings.Contains(output, `"alias": "access-request-plugin"`) {
-		t.Fatalf("expected manifest alias in payload, got: %s", output)
-	}
-	if strings.Contains(output, "outDir") || strings.Contains(output, "8080") {
-		t.Fatalf("local build section must not be in the payload, got: %s", output)
-	}
-}
+// --- command wiring (cobra + experimental gate), hermetic: fails at validation
+// before the dry-run alias check, so no client/network is exercised ---
 
 func TestCreateCommand_InvalidManifestSurfacesValidationError(t *testing.T) {
 	t.Setenv(experimentalUIPluginsEnvVar, "1")
@@ -451,7 +547,6 @@ func TestCreateCommand_InvalidManifestSurfacesValidationError(t *testing.T) {
 	defer restore()
 
 	cmd := NewUIPluginsCommand()
-	// --dry-run keeps this hermetic (no config/auth needed); validation runs first regardless.
 	cmd.SetArgs([]string{"create", "--dry-run"})
 	err := cmd.Execute()
 	if err == nil {

--- a/cmd/ui_plugins/manifest_model.go
+++ b/cmd/ui_plugins/manifest_model.go
@@ -20,9 +20,9 @@ type uiPluginManifest struct {
 	Name                    map[string]string   `json:"name"`
 	Description             map[string]string   `json:"description"`
 	APIScopes               []string            `json:"apiScopes,omitempty"`
-	ContentSecurityPolicies map[string][]string `json:"contentSecurityPolicies,omitempty"`
-	PermissionPolicy        map[string][]string `json:"permissionPolicy,omitempty"`
-	IframeAllow             map[string][]string `json:"iframeAllow,omitempty"`
+	ContentSecurityPolicies map[string][]string `json:"contentSecurityPolicies"`
+	PermissionPolicy        map[string][]string `json:"permissionPolicy"`
+	IframeAllow             map[string][]string `json:"iframeAllow"`
 	Slots                   []uiPluginSlot      `json:"slots"`
 }
 

--- a/cmd/ui_plugins/manifest_validation.go
+++ b/cmd/ui_plugins/manifest_validation.go
@@ -78,6 +78,18 @@ func validateWorkspaceManifest(cfg *uiPluginWorkspaceConfig) error {
 		}
 	}
 
+	// The backend requires these policy objects to be present; an empty object
+	// {} is accepted. Directive names/values are validated by UMS, not here.
+	if manifest.ContentSecurityPolicies == nil {
+		return fmt.Errorf("manifest.contentSecurityPolicies is required (use an empty object {} if the plugin declares no CSP directives)")
+	}
+	if manifest.PermissionPolicy == nil {
+		return fmt.Errorf("manifest.permissionPolicy is required (use an empty object {} if the plugin declares no permission-policy directives)")
+	}
+	if manifest.IframeAllow == nil {
+		return fmt.Errorf("manifest.iframeAllow is required (use an empty object {} if the plugin declares no iframe-allow directives)")
+	}
+
 	if cfg.Build != nil {
 		if cfg.Build.Port != nil && *cfg.Build.Port <= 0 {
 			return fmt.Errorf("build.port must be greater than 0")

--- a/cmd/ui_plugins/manifest_validation_test.go
+++ b/cmd/ui_plugins/manifest_validation_test.go
@@ -14,7 +14,10 @@ func TestLoadAndValidateWorkspaceManifest_Valid(t *testing.T) {
     "alias": "access-request-plugin",
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   },
   "build": {
     "outDir": "./dist",
@@ -42,6 +45,8 @@ func TestLoadAndValidateWorkspaceManifest_ValidIframeAllow(t *testing.T) {
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
     "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
     "iframeAllow": {}
   }
 }`)
@@ -63,6 +68,8 @@ func TestLoadAndValidateWorkspaceManifest_ValidIframeAllowWithDirectives(t *test
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
     "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
     "iframeAllow": {"camera": ["'self'"]}
   }
 }`)
@@ -111,7 +118,10 @@ func TestLoadAndValidateWorkspaceManifest_ValidSlotWithOptionalFields(t *testing
       "slotId": "full-page",
       "requiredCapabilities": ["ORG_ADMIN"],
       "restrictToUsers": ["2c9180827f9b911e017f9b9122340000"]
-    }]
+    }],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   }
 }`)
 
@@ -267,6 +277,50 @@ func TestLoadAndValidateWorkspaceManifest_MissingRequiredManifestField(t *testin
 	}
 	if !strings.Contains(err.Error(), "manifest.alias is required") {
 		t.Fatalf("expected alias required error, got: %v", err)
+	}
+}
+
+func TestLoadAndValidateWorkspaceManifest_MissingContentSecurityPolicies(t *testing.T) {
+	path := writeManifestFixture(t, `{
+  "version": 1,
+  "manifest": {
+    "alias": "access-request-plugin",
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}],
+    "permissionPolicy": {},
+    "iframeAllow": {}
+  }
+}`)
+
+	_, err := loadAndValidateWorkspaceManifest(path)
+	if err == nil {
+		t.Fatal("expected missing contentSecurityPolicies to fail")
+	}
+	if !strings.Contains(err.Error(), "manifest.contentSecurityPolicies is required") {
+		t.Fatalf("expected contentSecurityPolicies required error, got: %v", err)
+	}
+}
+
+func TestLoadAndValidateWorkspaceManifest_MissingIframeAllow(t *testing.T) {
+	path := writeManifestFixture(t, `{
+  "version": 1,
+  "manifest": {
+    "alias": "access-request-plugin",
+    "name": {"en-US": "Access Request"},
+    "description": {"en-US": "Plugin description"},
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {}
+  }
+}`)
+
+	_, err := loadAndValidateWorkspaceManifest(path)
+	if err == nil {
+		t.Fatal("expected missing iframeAllow to fail")
+	}
+	if !strings.Contains(err.Error(), "manifest.iframeAllow is required") {
+		t.Fatalf("expected iframeAllow required error, got: %v", err)
 	}
 }
 

--- a/cmd/ui_plugins/validate_manifest.md
+++ b/cmd/ui_plugins/validate_manifest.md
@@ -8,6 +8,7 @@ Performs an offline structural validation of `./sp-ui-plugin.json` in the curren
 - JSON shape, required fields, and known field types
 - Rejection of unknown fields (strict schema)
 - CLI config schema version support
+- Presence of the required policy objects (`contentSecurityPolicies`, `permissionPolicy`, `iframeAllow`); an empty object `{}` is accepted
 
 ## What is not checked
 
@@ -15,7 +16,7 @@ This command does not contact UMS or validate tenant-specific rules, including:
 
 - Alias availability or format rules enforced by the backend
 - Slot registry membership and occupancy limits
-- Security policy baselines (CSP, permission policy, iframe allow)
+- Security policy directive names/values and allowlists (CSP, permission policy, iframe allow) — only that the policy objects are present
 - Capability lists, user GUID restrictions, and related business rules
 
 Use `sail ui-plugins create` or `update` for full backend validation.

--- a/cmd/ui_plugins/validate_manifest_test.go
+++ b/cmd/ui_plugins/validate_manifest_test.go
@@ -17,7 +17,10 @@ func TestValidateManifestCommand_Success(t *testing.T) {
     "alias": "access-request-plugin",
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   }
 }`)
 
@@ -45,7 +48,10 @@ func TestValidateManifestCommand_RejectsExtraArgs(t *testing.T) {
     "alias": "access-request-plugin",
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   }
 }`)
 
@@ -72,7 +78,10 @@ func TestValidateManifestCommand_AliasSuccess(t *testing.T) {
     "alias": "access-request-plugin",
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   }
 }`)
 
@@ -94,7 +103,10 @@ func TestValidateManifestCommand_Failure(t *testing.T) {
   "manifest": {
     "name": {"en-US": "Access Request"},
     "description": {"en-US": "Plugin description"},
-    "slots": [{"slotId": "full-page"}]
+    "slots": [{"slotId": "full-page"}],
+    "contentSecurityPolicies": {},
+    "permissionPolicy": {},
+    "iframeAllow": {}
   }
 }`)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,32 @@ func CheckToken(tokenString string) error {
 	return nil
 }
 
+// GetCurrentIdentityID returns the identity GUID of the authenticated user,
+// read from the active access token's identity_id claim. It makes no API call.
+// It returns an error when the token cannot be obtained or carries no user
+// context (for example a service token without an associated identity).
+func GetCurrentIdentityID() (string, error) {
+	tokenString, err := GetAuthToken()
+	if err != nil {
+		return "", err
+	}
+
+	token, err := jwt.ParseSigned(tokenString)
+	if err != nil {
+		return "", err
+	}
+
+	var claims map[string]interface{}
+	token.UnsafeClaimsWithoutVerification(&claims)
+
+	identityID, _ := claims["identity_id"].(string)
+	if strings.TrimSpace(identityID) == "" {
+		return "", fmt.Errorf("could not determine the current user identity from the active token; authenticate with a user context to use this option")
+	}
+
+	return identityID, nil
+}
+
 func SetTime(inputTime time.Time) string {
 	return inputTime.Format(time.RFC3339)
 }


### PR DESCRIPTION
## Description
This PR adds the create subcommand to ui-plugins, which is responsible for creating a new plugin instance using a provided configuration file with optional overrides.

## How Has This Been Tested?
Built the project locally and manually tested all steps as part of writing up the MV (CSTM-300)
