### PR TITLE
CSTM-228: Adding list and delete commands to ui-plugins command group

### DIFF
--- a/cmd/ui_plugins/create.go
+++ b/cmd/ui_plugins/create.go
@@ -21,7 +21,7 @@ import (
 var createHelp string
 
 const (
-	pluginInstancesEndpoint = "/v2026/ui-plugins"
+	pluginInstancesEndpoint = "/ui-plugins/v1"
 	validateAliasEndpoint   = pluginInstancesEndpoint + "/validate-alias"
 
 	// experimentalHeader must be sent on ui-plugins requests while the routes are

--- a/cmd/ui_plugins/delete.go
+++ b/cmd/ui_plugins/delete.go
@@ -1,17 +1,99 @@
 package ui_plugins
 
 import (
+	"context"
+	_ "embed"
 	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"strings"
 
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
+//go:embed delete.md
+var deleteHelp string
+
 func newDeleteCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "delete",
-		Short: "Delete a UI plugin instance",
+	var force bool
+	var jsonOutput bool
+
+	help := util.ParseHelp(deleteHelp)
+	cmd := &cobra.Command{
+		Use:     "delete (alias | plugin-id)",
+		Short:   "Delete a UI plugin instance",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("`sail ui-plugins delete` is not implemented yet")
+			spClient, err := newPluginClient()
+			if err != nil {
+				return err
+			}
+			return runDelete(context.Background(), spClient, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], force, jsonOutput)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&force, "force", "F", false, "Bypass confirmation prompts")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the deleted plugin instance as JSON")
+
+	return cmd
+}
+
+// runDelete resolves the target (by alias or plugin ID), confirms the deletion
+// (unless force), then deletes it. The confirmation is skipped by force, but the
+// ambiguous-alias and not-found guards are always enforced. When jsonOutput is set,
+// the confirmation is written to errOut so stdout carries only the resulting JSON.
+func runDelete(ctx context.Context, c client.Client, in io.Reader, out io.Writer, errOut io.Writer, arg string, force bool, jsonOutput bool) error {
+	inst, raw, err := resolveDeleteTarget(ctx, c, arg)
+	if err != nil {
+		return err
+	}
+
+	if !force {
+		promptOut := out
+		if jsonOutput {
+			promptOut = errOut
+		}
+		renderDeleteConfirmation(promptOut, inst)
+
+		confirmed, err := promptYesNo(in, promptOut, fmt.Sprintf("Delete plugin instance %s?", inst.PluginInstanceID))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			_, _ = fmt.Fprintln(promptOut, "Cancelled.")
+			return nil
+		}
+	}
+
+	url := pluginInstancesEndpoint + "/" + neturl.PathEscape(inst.PluginInstanceID)
+	resp, err := c.Delete(ctx, url, nil, uiPluginRequestHeaders())
+	if err != nil {
+		return fmt.Errorf("failed to delete plugin instance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return mapUMSDeleteError(resp.StatusCode, body, inst.PluginInstanceID)
+	}
+
+	if jsonOutput {
+		_, _ = fmt.Fprintln(out, strings.TrimSpace(string(raw)))
+		return nil
+	}
+
+	if inst.Alias != "" {
+		_, _ = fmt.Fprintf(out, "Deleted plugin instance %s (alias: %s)\n", inst.PluginInstanceID, inst.Alias)
+	} else {
+		_, _ = fmt.Fprintf(out, "Deleted plugin instance %s\n", inst.PluginInstanceID)
+	}
+	return nil
 }

--- a/cmd/ui_plugins/delete.md
+++ b/cmd/ui_plugins/delete.md
@@ -1,0 +1,45 @@
+==Long==
+# Delete
+
+Deletes a UI plugin instance from the current tenant, identified by either its alias or its plugin ID.
+
+Before deleting, the command looks up the instance and prints a summary (alias, name, plugin ID, created date, and slots) for you to confirm. If the instance has an active asset bundle (a live deployment), a warning is shown.
+
+## Identifying the instance
+
+The single argument accepts either an alias or a plugin ID; the type is detected automatically by its shape:
+
+- A value in UUID form is treated as a plugin ID.
+- Anything else is treated as an alias and resolved to its plugin ID first.
+
+A UUID is technically also a valid alias. If you register an alias that looks like a UUID, this command will treat that argument as a plugin ID and report "not found" — it will never delete a different instance. Such an instance can still be deleted by passing its plugin ID.
+
+## Confirmation and --force
+
+Deletions require confirmation (the prompt defaults to No). `--force` (`-F`) skips the confirmation prompt only — it does not bypass safety checks:
+
+- If an alias resolves to more than one instance, the command lists the conflicting plugin IDs and stops, even with `--force`. Re-run with a specific plugin ID.
+- A missing instance is always reported as an error.
+
+## Output
+
+On success a confirmation with the deleted plugin ID (and alias, when known) is printed. Use `--json` to print the deleted plugin instance as JSON instead.
+====
+
+==Example==
+
+```bash
+# Delete by alias (prompts for confirmation)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins delete access-request-plugin
+
+# Delete by plugin ID
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins delete 2c918085-7a1e-1b2c-817a-1e1b2c000000
+
+# Skip the confirmation prompt
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins delete access-request-plugin --force
+
+# Print the deleted instance as JSON (scripting)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins delete access-request-plugin --force --json
+```
+
+====

--- a/cmd/ui_plugins/delete_test.go
+++ b/cmd/ui_plugins/delete_test.go
@@ -1,0 +1,211 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const resolvedAliasBody = `{"pluginInstanceId":"pi-1","alias":"my-plugin","name":{"en":"My Plugin"},"created":"2026-05-01T00:00:00Z","slots":[{"slotId":"full-page"}]}`
+
+func TestRunDelete_ConfirmYesDeletes(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: resolvedAliasBody}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.deleteCalls != 1 {
+		t.Fatalf("expected 1 Delete, got %d", c.deleteCalls)
+	}
+	if !strings.HasSuffix(c.deleteURL, "/pi-1") {
+		t.Fatalf("expected DELETE on resolved id, got: %s", c.deleteURL)
+	}
+	got := out.String()
+	if !strings.Contains(got, "full-page") {
+		t.Fatalf("expected confirmation to show slots, got: %s", got)
+	}
+	if !strings.Contains(got, "Deleted plugin instance pi-1") || !strings.Contains(got, "my-plugin") {
+		t.Fatalf("expected success message with id and alias, got: %s", got)
+	}
+}
+
+func TestRunDelete_DeclineDoesNotDelete(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: resolvedAliasBody}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader("n\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.deleteCalls != 0 {
+		t.Fatal("declining must not call Delete")
+	}
+	if !strings.Contains(out.String(), "Cancelled.") {
+		t.Fatalf("expected cancellation message, got: %s", out.String())
+	}
+}
+
+func TestRunDelete_EmptyInputDefaultsToNo(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: resolvedAliasBody}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader("\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.deleteCalls != 0 {
+		t.Fatal("empty input must default to No and not delete")
+	}
+}
+
+func TestRunDelete_ForceSkipsPrompt(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: resolvedAliasBody}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out bytes.Buffer
+
+	// Empty stdin: if the prompt were shown, it would default to No and skip Delete.
+	err := runDelete(context.Background(), c, strings.NewReader(""), &out, &out, "my-plugin", true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.deleteCalls != 1 {
+		t.Fatalf("--force should delete without prompting, got %d Delete calls", c.deleteCalls)
+	}
+	if strings.Contains(out.String(), "[y/N]") {
+		t.Fatalf("--force should not print a prompt, got: %s", out.String())
+	}
+}
+
+func TestRunDelete_AmbiguousNotDeletedEvenWithForce(t *testing.T) {
+	body := `{"conflicts":[{"pluginInstanceId":"pi-1"},{"pluginInstanceId":"pi-2"}]}`
+	c := &seqClient{getQueue: []stubResp{{status: 409, body: body}}}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader(""), &out, &out, "dup-plugin", true, false)
+	if err == nil {
+		t.Fatal("expected ambiguity error even with --force")
+	}
+	if c.deleteCalls != 0 {
+		t.Fatal("ambiguous alias must never be deleted, even with --force")
+	}
+	if !strings.Contains(err.Error(), "pi-1") || !strings.Contains(err.Error(), "pi-2") {
+		t.Fatalf("expected conflicting IDs in error, got: %v", err)
+	}
+}
+
+func TestRunDelete_NotFoundBeforePrompt(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 404, body: `{"message":"Not Found"}`}}}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader("y\n"), &out, &out, "missing", false, false)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got: %v", err)
+	}
+	if c.deleteCalls != 0 {
+		t.Fatal("must not delete when target not found")
+	}
+	if strings.Contains(out.String(), "[y/N]") {
+		t.Fatalf("must not prompt when target resolution fails, got: %s", out.String())
+	}
+}
+
+func TestRunDelete_ActiveBundleWarning(t *testing.T) {
+	body := `{"pluginInstanceId":"pi-1","alias":"my-plugin","activeAssetBundleId":"ab-9","slots":[{"slotId":"full-page"}]}`
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: body}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "active asset bundle") {
+		t.Fatalf("expected active-deployment warning, got: %s", out.String())
+	}
+}
+
+func TestRunDelete_JSONEmitsInstanceOnStdout(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: resolvedAliasBody}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out, errOut bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader(""), &out, &errOut, "my-plugin", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), `"pluginInstanceId":"pi-1"`) {
+		t.Fatalf("expected deleted instance JSON on stdout, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "Deleted plugin instance") {
+		t.Fatalf("--json stdout should be pure JSON, got: %s", out.String())
+	}
+}
+
+func TestRunDelete_DeleteErrorMapping(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: resolvedAliasBody}},
+		deleteResp: stubResp{status: 403, body: `{"message":"Forbidden"}`},
+	}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err == nil || !strings.Contains(err.Error(), "not authorized to delete") {
+		t.Fatalf("expected delete forbidden mapping, got: %v", err)
+	}
+}
+
+func TestRunDelete_TransportError(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: resolvedAliasBody}},
+		deleteResp: stubResp{err: errors.New("connection refused")},
+	}
+	var out bytes.Buffer
+
+	err := runDelete(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err == nil || !strings.Contains(err.Error(), "failed to delete plugin instance") {
+		t.Fatalf("expected wrapped transport error, got: %v", err)
+	}
+}
+
+func TestMapUMSErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"list 400", mapUMSListError(400, []byte(`{"message":"bad"}`)), "invalid request listing"},
+		{"list 403", mapUMSListError(403, []byte(`{}`)), "not authorized to list"},
+		{"list 404", mapUMSListError(404, []byte(`{}`)), "not enabled"},
+		{"list 500", mapUMSListError(500, []byte(`{"message":"boom"}`)), "status 500"},
+		{"lookup 403", mapUMSLookupError(403, []byte(`{}`), "x"), "not authorized to read"},
+		{"lookup 404", mapUMSLookupError(404, []byte(`{}`), "x"), "not found"},
+		{"delete 403", mapUMSDeleteError(403, []byte(`{}`), "x"), "not authorized to delete"},
+		{"delete 404", mapUMSDeleteError(404, []byte(`{}`), "x"), "not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err == nil || !strings.Contains(tt.err.Error(), tt.want) {
+				t.Fatalf("expected %q, got: %v", tt.want, tt.err)
+			}
+		})
+	}
+}

--- a/cmd/ui_plugins/list.go
+++ b/cmd/ui_plugins/list.go
@@ -1,17 +1,75 @@
 package ui_plugins
 
 import (
+	"context"
+	_ "embed"
+	"encoding/json"
 	"fmt"
+	"io"
 
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
+//go:embed list.md
+var listHelp string
+
 func newListCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "list",
-		Short: "List UI plugin instances in the current tenant",
+	var jsonOutput bool
+
+	help := util.ParseHelp(listHelp)
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List UI plugin instances in the current tenant",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("`sail ui-plugins list` is not implemented yet")
+			spClient, err := newPluginClient()
+			if err != nil {
+				return err
+			}
+			return runList(context.Background(), spClient, cmd.OutOrStdout(), jsonOutput)
 		},
 	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the raw plugin instance list as JSON")
+
+	return cmd
+}
+
+// runList fetches all plugin instances for the active tenant and renders them as a
+// table, or as the raw aggregated JSON array when jsonOutput is set.
+func runList(ctx context.Context, c client.Client, out io.Writer, jsonOutput bool) error {
+	raw, err := listPluginInstances(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		encoded, err := json.MarshalIndent(raw, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to encode plugin instances: %w", err)
+		}
+		_, _ = fmt.Fprintln(out, string(encoded))
+		return nil
+	}
+
+	instances := make([]pluginInstance, 0, len(raw))
+	for _, item := range raw {
+		var inst pluginInstance
+		if err := json.Unmarshal(item, &inst); err != nil {
+			return fmt.Errorf("failed to parse plugin instance: %w", err)
+		}
+		instances = append(instances, inst)
+	}
+
+	if len(instances) == 0 {
+		_, _ = fmt.Fprintln(out, "No plugin instances found.")
+		return nil
+	}
+
+	renderPluginInstanceTable(out, instances)
+	return nil
 }

--- a/cmd/ui_plugins/list.md
+++ b/cmd/ui_plugins/list.md
@@ -7,7 +7,7 @@ All instances are returned — the command pages through the backend internally,
 
 ## Output
 
-By default a table is printed; an empty tenant prints `No plugin instances found.` Use `--json` to print the raw plugin instance list as a JSON array instead (useful for scripting).
+By default a table is printed; an empty tenant prints `No plugin instances found.` Long author-entered values (alias, name) are truncated with an ellipsis to keep the table readable — use `--json` to print the raw, untruncated plugin instance list as a JSON array (useful for scripting).
 ====
 
 ==Example==

--- a/cmd/ui_plugins/list.md
+++ b/cmd/ui_plugins/list.md
@@ -1,0 +1,23 @@
+==Long==
+# List
+
+Lists the UI plugin instances registered in the current tenant.
+
+All instances are returned — the command pages through the backend internally, so there is no need to specify a limit or offset. Results are shown as a table sorted by alias, with the columns Alias, Id, Name, and Created.
+
+## Output
+
+By default a table is printed; an empty tenant prints `No plugin instances found.` Use `--json` to print the raw plugin instance list as a JSON array instead (useful for scripting).
+====
+
+==Example==
+
+```bash
+# List all plugin instances in the current tenant
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins list
+
+# Print the raw list as JSON
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins list --json
+```
+
+====

--- a/cmd/ui_plugins/list_test.go
+++ b/cmd/ui_plugins/list_test.go
@@ -1,0 +1,79 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRunList_Table(t *testing.T) {
+	body := `[
+	  {"pluginInstanceId":"pi-2","alias":"zeta-plugin","name":{"en":"Zeta"},"created":"2026-06-01T00:00:00Z"},
+	  {"pluginInstanceId":"pi-1","alias":"alpha-plugin","name":{"en":"Alpha"},"created":"2026-05-01T00:00:00Z"}
+	]`
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: body}}}
+	var out bytes.Buffer
+
+	if err := runList(context.Background(), c, &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	// tablewriter upper-cases headers; assert on the header labels (upper) and the row data.
+	for _, want := range []string{"ALIAS", "ID", "NAME", "CREATED", "alpha-plugin", "zeta-plugin", "pi-1", "Alpha"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected table to contain %q, got:\n%s", want, got)
+		}
+	}
+	// Sorted by alias: alpha before zeta.
+	if strings.Index(got, "alpha-plugin") > strings.Index(got, "zeta-plugin") {
+		t.Fatalf("expected rows sorted by alias, got:\n%s", got)
+	}
+}
+
+func TestRunList_Empty(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: `[]`}}}
+	var out bytes.Buffer
+
+	if err := runList(context.Background(), c, &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "No plugin instances found.") {
+		t.Fatalf("expected friendly empty message, got: %s", out.String())
+	}
+}
+
+func TestRunList_JSONFidelity(t *testing.T) {
+	// Includes a field not modeled by pluginInstance to prove --json is loss-free.
+	body := `[{"pluginInstanceId":"pi-1","alias":"a","devOverrides":{"someId":"http://localhost"}}]`
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: body}}}
+	var out bytes.Buffer
+
+	if err := runList(context.Background(), c, &out, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "devOverrides") || !strings.Contains(out.String(), "localhost") {
+		t.Fatalf("expected raw fields preserved in --json, got: %s", out.String())
+	}
+	// Output must be a valid JSON array.
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &arr); err != nil {
+		t.Fatalf("expected valid JSON array, got error %v for: %s", err, out.String())
+	}
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(arr))
+	}
+}
+
+func TestRunList_JSONEmptyIsArray(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: `[]`}}}
+	var out bytes.Buffer
+
+	if err := runList(context.Background(), c, &out, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "[]" {
+		t.Fatalf("expected empty JSON array, got: %s", out.String())
+	}
+}

--- a/cmd/ui_plugins/plugin_instance.go
+++ b/cmd/ui_plugins/plugin_instance.go
@@ -22,6 +22,10 @@ const (
 	resolveAliasEndpoint = pluginInstancesEndpoint + "/resolve-alias"
 	// pluginInstancesPageSize is the UMS maximum page size for the list endpoint.
 	pluginInstancesPageSize = 250
+	// tableColumnMaxWidth caps the width of author-entered columns (alias, name) in
+	// the list table so long values don't blow out the layout. Full values are always
+	// available via --json.
+	tableColumnMaxWidth = 40
 )
 
 // pluginInstance is the subset of the UMS PluginInstanceDto the list and delete
@@ -189,13 +193,33 @@ func localizedName(name map[string]string) string {
 }
 
 // renderPluginInstanceTable prints instances as an Alias/Id/Name/Created table,
-// sorted by alias.
+// sorted by alias. Author-entered columns (alias, name) are truncated for layout;
+// full values remain available via --json.
 func renderPluginInstanceTable(w io.Writer, items []pluginInstance) {
 	rows := make([][]string, 0, len(items))
 	for _, p := range items {
-		rows = append(rows, []string{p.Alias, p.PluginInstanceID, localizedName(p.Name), p.Created})
+		rows = append(rows, []string{
+			truncateForTable(p.Alias, tableColumnMaxWidth),
+			p.PluginInstanceID,
+			truncateForTable(localizedName(p.Name), tableColumnMaxWidth),
+			p.Created,
+		})
 	}
 	output.WriteTable(w, []string{"Alias", "Id", "Name", "Created"}, rows, "Alias")
+}
+
+// truncateForTable shortens s to at most maxRunes runes, appending an ellipsis when
+// truncated. It counts runes, not bytes, so multibyte author-entered text is never
+// split mid-character.
+func truncateForTable(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	if maxRunes <= 1 {
+		return "…"
+	}
+	return string(runes[:maxRunes-1]) + "…"
 }
 
 // renderDeleteConfirmation prints the details of the instance about to be deleted,

--- a/cmd/ui_plugins/plugin_instance.go
+++ b/cmd/ui_plugins/plugin_instance.go
@@ -1,0 +1,278 @@
+package ui_plugins
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/output"
+)
+
+const (
+	// resolveAliasEndpoint returns the full plugin instance for a tenant-unique alias.
+	// It is distinct from validateAliasEndpoint (used by create), which only checks availability.
+	resolveAliasEndpoint = pluginInstancesEndpoint + "/resolve-alias"
+	// pluginInstancesPageSize is the UMS maximum page size for the list endpoint.
+	pluginInstancesPageSize = 250
+)
+
+// pluginInstance is the subset of the UMS PluginInstanceDto the list and delete
+// commands need for display. Unrecognized fields are ignored on decode; the raw
+// body is preserved separately when --json fidelity is required.
+type pluginInstance struct {
+	PluginInstanceID    string            `json:"pluginInstanceId"`
+	Alias               string            `json:"alias"`
+	Name                map[string]string `json:"name"`
+	Created             string            `json:"created"`
+	Slots               []uiPluginSlot    `json:"slots"`
+	ActiveAssetBundleID *string           `json:"activeAssetBundleId"`
+}
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// looksLikeUUID reports whether s has the canonical 8-4-4-4-12 UUID shape. A UUID
+// is also a syntactically valid alias, so an alias that happens to look like a UUID
+// is treated as a plugin ID; this is harmless (it resolves to "not found" rather
+// than deleting the wrong instance) and is documented in delete.md.
+func looksLikeUUID(s string) bool {
+	return uuidPattern.MatchString(strings.TrimSpace(s))
+}
+
+// listPluginInstances fetches every plugin instance for the active tenant, paging
+// through the UMS list endpoint until a short page is returned. Items are kept as
+// raw JSON so --json can emit them without field loss.
+func listPluginInstances(ctx context.Context, c client.Client) ([]json.RawMessage, error) {
+	all := []json.RawMessage{}
+	headers := uiPluginRequestHeaders()
+
+	for offset := 0; ; offset += pluginInstancesPageSize {
+		url := fmt.Sprintf("%s?limit=%d&offset=%d", pluginInstancesEndpoint, pluginInstancesPageSize, offset)
+		resp, err := c.Get(ctx, url, headers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list plugin instances: %w", err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return nil, mapUMSListError(resp.StatusCode, body)
+		}
+
+		var page []json.RawMessage
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("failed to parse plugin instance list: %w", err)
+		}
+		all = append(all, page...)
+
+		if len(page) < pluginInstancesPageSize {
+			break
+		}
+	}
+
+	return all, nil
+}
+
+// resolveDeleteTarget resolves a delete argument to a plugin instance, choosing the
+// lookup by the argument's shape: a UUID is looked up by ID, anything else by alias.
+// It returns the typed instance and its raw response body (for --json).
+func resolveDeleteTarget(ctx context.Context, c client.Client, arg string) (*pluginInstance, []byte, error) {
+	if looksLikeUUID(arg) {
+		return getPluginInstanceByID(ctx, c, arg)
+	}
+	return resolvePluginInstanceByAlias(ctx, c, arg)
+}
+
+// getPluginInstanceByID fetches a single instance by its UUID.
+func getPluginInstanceByID(ctx context.Context, c client.Client, id string) (*pluginInstance, []byte, error) {
+	url := pluginInstancesEndpoint + "/" + neturl.PathEscape(id)
+	resp, err := c.Get(ctx, url, uiPluginRequestHeaders())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to look up plugin instance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, nil, mapUMSLookupError(resp.StatusCode, body, id)
+	}
+
+	var inst pluginInstance
+	if err := json.Unmarshal(body, &inst); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse plugin instance: %w", err)
+	}
+	return &inst, body, nil
+}
+
+// resolvePluginInstanceByAlias resolves a tenant-unique alias to its instance. An
+// ambiguous alias (409) is reported with the conflicting plugin IDs and never
+// auto-resolved — the caller must re-run with a specific plugin ID.
+func resolvePluginInstanceByAlias(ctx context.Context, c client.Client, alias string) (*pluginInstance, []byte, error) {
+	url := resolveAliasEndpoint + "?alias=" + neturl.QueryEscape(alias)
+	resp, err := c.Get(ctx, url, uiPluginRequestHeaders())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve alias: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusConflict {
+		return nil, nil, ambiguousAliasError(alias, body)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, nil, mapUMSLookupError(resp.StatusCode, body, alias)
+	}
+
+	var inst pluginInstance
+	if err := json.Unmarshal(body, &inst); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse plugin instance: %w", err)
+	}
+	return &inst, body, nil
+}
+
+// ambiguousAliasError builds an actionable error listing the plugin IDs an alias
+// resolves to, so the user can re-run delete with a specific ID.
+func ambiguousAliasError(alias string, body []byte) error {
+	var parsed struct {
+		Conflicts []pluginInstance `json:"conflicts"`
+	}
+	var ids []string
+	if json.Unmarshal(body, &parsed) == nil {
+		for _, c := range parsed.Conflicts {
+			if c.PluginInstanceID != "" {
+				ids = append(ids, c.PluginInstanceID)
+			}
+		}
+	}
+	if len(ids) > 0 {
+		return fmt.Errorf("alias %q resolves to multiple plugin instances (%s); re-run delete with a specific plugin ID", alias, strings.Join(ids, ", "))
+	}
+	return fmt.Errorf("alias %q resolves to multiple plugin instances; re-run delete with a specific plugin ID: %s", alias, umsErrorMessage(body))
+}
+
+// localizedName returns a display name from a localized name map, preferring the
+// English locale and falling back to the first locale in sorted order.
+func localizedName(name map[string]string) string {
+	for _, key := range []string{"en", "en-US"} {
+		if v := strings.TrimSpace(name[key]); v != "" {
+			return v
+		}
+	}
+	keys := make([]string, 0, len(name))
+	for k := range name {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if v := strings.TrimSpace(name[k]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// renderPluginInstanceTable prints instances as an Alias/Id/Name/Created table,
+// sorted by alias.
+func renderPluginInstanceTable(w io.Writer, items []pluginInstance) {
+	rows := make([][]string, 0, len(items))
+	for _, p := range items {
+		rows = append(rows, []string{p.Alias, p.PluginInstanceID, localizedName(p.Name), p.Created})
+	}
+	output.WriteTable(w, []string{"Alias", "Id", "Name", "Created"}, rows, "Alias")
+}
+
+// renderDeleteConfirmation prints the details of the instance about to be deleted,
+// warning when it has an active asset bundle (a live deployment).
+func renderDeleteConfirmation(w io.Writer, inst *pluginInstance) {
+	fmt.Fprintln(w, "You are about to delete the following UI plugin instance:")
+	fmt.Fprintf(w, "  Alias:     %s\n", inst.Alias)
+	fmt.Fprintf(w, "  Name:      %s\n", localizedName(inst.Name))
+	fmt.Fprintf(w, "  Plugin ID: %s\n", inst.PluginInstanceID)
+	if inst.Created != "" {
+		fmt.Fprintf(w, "  Created:   %s\n", inst.Created)
+	}
+	if len(inst.Slots) > 0 {
+		ids := make([]string, 0, len(inst.Slots))
+		for _, s := range inst.Slots {
+			ids = append(ids, s.SlotID)
+		}
+		fmt.Fprintf(w, "  Slots:     %s\n", strings.Join(ids, ", "))
+	}
+	if inst.ActiveAssetBundleID != nil && strings.TrimSpace(*inst.ActiveAssetBundleID) != "" {
+		fmt.Fprintln(w, "  WARNING:   This plugin has an active asset bundle (a live deployment).")
+	}
+}
+
+// promptYesNo asks question and returns true only for an explicit yes. An empty
+// response (or EOF) defaults to No.
+func promptYesNo(in io.Reader, w io.Writer, question string) (bool, error) {
+	fmt.Fprintf(w, "%s [y/N]: ", question)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+// mapUMSListError translates a non-2xx list response into an actionable error.
+func mapUMSListError(status int, body []byte) error {
+	message := umsErrorMessage(body)
+	switch status {
+	case http.StatusBadRequest:
+		return fmt.Errorf("invalid request listing plugin instances: %s", message)
+	case http.StatusForbidden:
+		return fmt.Errorf("not authorized to list UI plugins (requires the idn:plugins-ui:read right): %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("the UI plugins feature is not enabled for this tenant, or the endpoint is unavailable: %s", message)
+	default:
+		return fmt.Errorf("failed to list plugin instances (status %d): %s", status, message)
+	}
+}
+
+// mapUMSLookupError translates a non-2xx resolve/get response into an actionable error.
+func mapUMSLookupError(status int, body []byte, target string) error {
+	message := umsErrorMessage(body)
+	switch status {
+	case http.StatusBadRequest:
+		return fmt.Errorf("invalid plugin instance identifier %q: %s", target, message)
+	case http.StatusForbidden:
+		return fmt.Errorf("not authorized to read UI plugins (requires the idn:plugins-ui:read right): %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("plugin instance %q not found (or the UI plugins feature is not enabled for this tenant): %s", target, message)
+	default:
+		return fmt.Errorf("failed to look up plugin instance %q (status %d): %s", target, status, message)
+	}
+}
+
+// mapUMSDeleteError translates a non-2xx delete response into an actionable error.
+func mapUMSDeleteError(status int, body []byte, target string) error {
+	message := umsErrorMessage(body)
+	switch status {
+	case http.StatusBadRequest:
+		return fmt.Errorf("invalid plugin instance identifier %q: %s", target, message)
+	case http.StatusForbidden:
+		return fmt.Errorf("not authorized to delete UI plugins (requires the idn:plugins-ui:delete right): %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("plugin instance %q not found: %s", target, message)
+	default:
+		return fmt.Errorf("failed to delete plugin instance %q (status %d): %s", target, status, message)
+	}
+}

--- a/cmd/ui_plugins/plugin_instance_test.go
+++ b/cmd/ui_plugins/plugin_instance_test.go
@@ -1,0 +1,233 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// stubResp is a canned HTTP response for the sequenced test client.
+type stubResp struct {
+	status int
+	body   string
+	err    error
+}
+
+// seqClient is a test double for client.Client that returns queued Get responses in
+// order (for pagination and lookups) and a single canned Delete response. It records
+// the URLs it was called with. Post/Put/Patch are unused here.
+type seqClient struct {
+	getQueue   []stubResp
+	getURLs    []string
+	getHeaders []map[string]string
+
+	deleteResp    stubResp
+	deleteCalls   int
+	deleteURL     string
+	deleteHeaders map[string]string
+}
+
+func (s *seqClient) Get(ctx context.Context, url string, headers map[string]string) (*http.Response, error) {
+	s.getURLs = append(s.getURLs, url)
+	s.getHeaders = append(s.getHeaders, headers)
+	if len(s.getQueue) == 0 {
+		return nil, errors.New("seqClient: no queued Get response")
+	}
+	r := s.getQueue[0]
+	s.getQueue = s.getQueue[1:]
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &http.Response{StatusCode: r.status, Body: io.NopCloser(strings.NewReader(r.body))}, nil
+}
+
+func (s *seqClient) Delete(ctx context.Context, url string, params map[string]string, headers map[string]string) (*http.Response, error) {
+	s.deleteCalls++
+	s.deleteURL = url
+	s.deleteHeaders = headers
+	if s.deleteResp.err != nil {
+		return nil, s.deleteResp.err
+	}
+	return &http.Response{StatusCode: s.deleteResp.status, Body: io.NopCloser(strings.NewReader(s.deleteResp.body))}, nil
+}
+
+func (s *seqClient) Post(ctx context.Context, url, contentType string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	return nil, errors.New("unused")
+}
+func (s *seqClient) Put(ctx context.Context, url, contentType string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	return nil, errors.New("unused")
+}
+func (s *seqClient) Patch(ctx context.Context, url string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	return nil, errors.New("unused")
+}
+
+func TestListAndDeleteSendExperimentalHeader(t *testing.T) {
+	// list
+	lc := &seqClient{getQueue: []stubResp{{status: 200, body: `[]`}}}
+	if _, err := listPluginInstances(context.Background(), lc); err != nil {
+		t.Fatalf("list: unexpected error: %v", err)
+	}
+	if got := lc.getHeaders[0][experimentalHeader]; got != "true" {
+		t.Fatalf("list request missing %s header, got headers: %v", experimentalHeader, lc.getHeaders[0])
+	}
+
+	// delete (both the resolve GET and the DELETE must carry the header)
+	dc := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: `{"pluginInstanceId":"pi-1","alias":"a"}`}},
+		deleteResp: stubResp{status: 204},
+	}
+	var sink bytes.Buffer
+	if err := runDelete(context.Background(), dc, strings.NewReader(""), &sink, &sink, "a", true, false); err != nil {
+		t.Fatalf("delete: unexpected error: %v", err)
+	}
+	if got := dc.getHeaders[0][experimentalHeader]; got != "true" {
+		t.Fatalf("resolve request missing %s header, got: %v", experimentalHeader, dc.getHeaders[0])
+	}
+	if got := dc.deleteHeaders[experimentalHeader]; got != "true" {
+		t.Fatalf("delete request missing %s header, got: %v", experimentalHeader, dc.deleteHeaders)
+	}
+}
+
+func TestLooksLikeUUID(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"2c918085-7a1e-1b2c-817a-1e1b2c000000", true},
+		{"  2c918085-7a1e-1b2c-817a-1e1b2c000000  ", true},
+		{"access-request-plugin", false},
+		{"", false},
+		{"2c918085-7a1e-1b2c-817a", false},
+		{"deadbeef-dead-beef-dead-beefdeadbeef", true}, // UUID-shaped alias: accepted edge case
+	}
+	for _, tt := range tests {
+		if got := looksLikeUUID(tt.in); got != tt.want {
+			t.Fatalf("looksLikeUUID(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestLocalizedName(t *testing.T) {
+	tests := []struct {
+		name map[string]string
+		want string
+	}{
+		{map[string]string{"en": "English", "fr": "French"}, "English"},
+		{map[string]string{"en-US": "US English"}, "US English"},
+		{map[string]string{"fr": "French", "de": "German"}, "German"}, // first sorted key
+		{map[string]string{}, ""},
+		{nil, ""},
+	}
+	for _, tt := range tests {
+		if got := localizedName(tt.name); got != tt.want {
+			t.Fatalf("localizedName(%v) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestListPluginInstances_SinglePage(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: `[{"pluginInstanceId":"a"},{"pluginInstanceId":"b"}]`}}}
+
+	items, err := listPluginInstances(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if len(c.getURLs) != 1 {
+		t.Fatalf("expected 1 Get, got %d", len(c.getURLs))
+	}
+	if !strings.Contains(c.getURLs[0], "limit=250") || !strings.Contains(c.getURLs[0], "offset=0") {
+		t.Fatalf("unexpected list URL: %s", c.getURLs[0])
+	}
+}
+
+func TestListPluginInstances_Paginates(t *testing.T) {
+	full := "[" + strings.Repeat(`{"pluginInstanceId":"x"},`, pluginInstancesPageSize-1) + `{"pluginInstanceId":"x"}]`
+	c := &seqClient{getQueue: []stubResp{
+		{status: 200, body: full},                          // exactly 250 -> fetch again
+		{status: 200, body: `[{"pluginInstanceId":"y"}]`},  // short page -> stop
+	}}
+
+	items, err := listPluginInstances(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != pluginInstancesPageSize+1 {
+		t.Fatalf("expected %d items, got %d", pluginInstancesPageSize+1, len(items))
+	}
+	if len(c.getURLs) != 2 {
+		t.Fatalf("expected 2 Gets, got %d", len(c.getURLs))
+	}
+	if !strings.Contains(c.getURLs[1], "offset=250") {
+		t.Fatalf("expected second page offset=250, got: %s", c.getURLs[1])
+	}
+}
+
+func TestListPluginInstances_ErrorMapping(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 403, body: `{"message":"Forbidden"}`}}}
+	_, err := listPluginInstances(context.Background(), c)
+	if err == nil || !strings.Contains(err.Error(), "not authorized to list") {
+		t.Fatalf("expected forbidden mapping, got: %v", err)
+	}
+}
+
+func TestResolveDeleteTarget_UUIDUsesGetByID(t *testing.T) {
+	id := "2c918085-7a1e-1b2c-817a-1e1b2c000000"
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: `{"pluginInstanceId":"` + id + `","alias":"my-plugin"}`}}}
+
+	inst, _, err := resolveDeleteTarget(context.Background(), c, id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst.PluginInstanceID != id {
+		t.Fatalf("expected id %s, got %s", id, inst.PluginInstanceID)
+	}
+	if !strings.HasSuffix(c.getURLs[0], "/"+id) {
+		t.Fatalf("expected get-by-id URL, got: %s", c.getURLs[0])
+	}
+}
+
+func TestResolveDeleteTarget_AliasUsesResolve(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: `{"pluginInstanceId":"pi-1","alias":"my-plugin"}`}}}
+
+	inst, _, err := resolveDeleteTarget(context.Background(), c, "my-plugin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst.PluginInstanceID != "pi-1" {
+		t.Fatalf("expected pi-1, got %s", inst.PluginInstanceID)
+	}
+	if !strings.Contains(c.getURLs[0], "resolve-alias") || !strings.Contains(c.getURLs[0], "alias=my-plugin") {
+		t.Fatalf("expected resolve-alias URL, got: %s", c.getURLs[0])
+	}
+}
+
+func TestResolveDeleteTarget_NotFound(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 404, body: `{"message":"Not Found"}`}}}
+	_, _, err := resolveDeleteTarget(context.Background(), c, "missing-plugin")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got: %v", err)
+	}
+}
+
+func TestResolveDeleteTarget_AmbiguousAlias(t *testing.T) {
+	body := `{"message":"Alias resolves to multiple plugin instances","conflicts":[{"pluginInstanceId":"pi-1"},{"pluginInstanceId":"pi-2"}]}`
+	c := &seqClient{getQueue: []stubResp{{status: 409, body: body}}}
+
+	_, _, err := resolveDeleteTarget(context.Background(), c, "dup-plugin")
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "pi-1") || !strings.Contains(err.Error(), "pi-2") {
+		t.Fatalf("expected conflicting IDs in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "specific plugin ID") {
+		t.Fatalf("expected guidance to use a plugin ID, got: %v", err)
+	}
+}

--- a/cmd/ui_plugins/plugin_instance_test.go
+++ b/cmd/ui_plugins/plugin_instance_test.go
@@ -111,6 +111,30 @@ func TestLooksLikeUUID(t *testing.T) {
 	}
 }
 
+func TestTruncateForTable(t *testing.T) {
+	tests := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"short", 40, "short"},
+		{"exactly-ten", 11, "exactly-ten"}, // len == max, unchanged
+		{"this-is-a-very-long-alias-value", 10, "this-is-a…"},
+		{"café-plugin-with-accents-that-runs-long", 10, "café-plug…"}, // rune-safe
+		{"x", 1, "x"},
+		{"xy", 1, "…"},
+	}
+	for _, tt := range tests {
+		if got := truncateForTable(tt.in, tt.max); got != tt.want {
+			t.Fatalf("truncateForTable(%q, %d) = %q, want %q", tt.in, tt.max, got, tt.want)
+		}
+	}
+	// The multibyte case must not split a rune: result stays valid UTF-8.
+	if got := truncateForTable("héllo-wörld-café", 8); len([]rune(got)) != 8 {
+		t.Fatalf("expected 8 runes, got %d (%q)", len([]rune(got)), got)
+	}
+}
+
 func TestLocalizedName(t *testing.T) {
 	tests := []struct {
 		name map[string]string
@@ -150,8 +174,8 @@ func TestListPluginInstances_SinglePage(t *testing.T) {
 func TestListPluginInstances_Paginates(t *testing.T) {
 	full := "[" + strings.Repeat(`{"pluginInstanceId":"x"},`, pluginInstancesPageSize-1) + `{"pluginInstanceId":"x"}]`
 	c := &seqClient{getQueue: []stubResp{
-		{status: 200, body: full},                          // exactly 250 -> fetch again
-		{status: 200, body: `[{"pluginInstanceId":"y"}]`},  // short page -> stop
+		{status: 200, body: full},                         // exactly 250 -> fetch again
+		{status: 200, body: `[{"pluginInstanceId":"y"}]`}, // short page -> stop
 	}}
 
 	items, err := listPluginInstances(context.Background(), c)


### PR DESCRIPTION
## Description
This PR adds the `list` and `delete` commands to the ui-plugins command group. Deletes are gated behind a verify confirmation (bypassed with --force). Delete can be by alias or by plugin id. If duplicate aliases are found the CLI errors out with a message to the end user. This happens regardless of the --force flag.

This PR also updates the plugins to use the new versioned endpoint.

## How Has This Been Tested?
There is an MV at CSTM-310 that documents the tests run including the edge cases. 
