### PR TITLE
Implements the `sail ui-plugins init` command (previously a stub) that gets a plugin author to a clean starting point in one step — either scaffolding a new Angular workspace or wiring an existing project for the SDK.

### DIFF
--- a/cmd/ui_plugins/init.go
+++ b/cmd/ui_plugins/init.go
@@ -1,17 +1,433 @@
 package ui_plugins
 
 import (
+	"bufio"
+	"context"
+	_ "embed"
 	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
 
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/initialize"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
+//go:embed init.md
+var initHelp string
+
+const (
+	uiPluginTemplatesRepoOwner = "sailpoint-oss"
+	uiPluginTemplatesRepoName  = "ui-plugin-templates"
+	uiPluginTemplatesBranch    = "main"
+	angularStarterSubdir       = "angular/starter"
+	genericGuideFileName       = "SAILPOINT_PLUGIN_GUIDE.md"
+	defaultDevServerPort       = 3000
+
+	// maxAliasPrompts bounds the interactive re-prompt loop so exhausted stdin
+	// (EOF) can't spin it forever.
+	maxAliasPrompts = 5
+)
+
+// initOptions holds the resolved flag values for the init command.
+type initOptions struct {
+	name    string
+	alias   string
+	path    string
+	outDir  string
+	port    int
+	portSet bool
+	force   bool
+}
+
+// initDeps carries the command's I/O plus the network-touching seams (scaffold
+// and fetchGuide) so the orchestration is testable without GitHub or a live
+// tenant.
+type initDeps struct {
+	client     client.Client
+	in         io.Reader
+	out        io.Writer
+	errOut     io.Writer
+	scaffold   func(destDir string) error  // fetch + extract the angular starter subtree
+	fetchGuide func(destPath string) error // fetch + write the generic guide
+}
+
 func newInitCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "init",
-		Short: "Initialize a UI plugin workspace",
+	var opts initOptions
+
+	help := util.ParseHelp(initHelp)
+	cmd := &cobra.Command{
+		Use:     "init [plugin-name]",
+		Short:   "Scaffold a new UI plugin workspace or attach the SDK to an existing project",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("`sail ui-plugins init` is not implemented yet")
+			if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
+				opts.name = args[0]
+			}
+			opts.name = strings.TrimSpace(opts.name)
+			opts.alias = strings.TrimSpace(opts.alias)
+			opts.path = strings.TrimSpace(opts.path)
+			opts.outDir = strings.TrimSpace(opts.outDir)
+			opts.portSet = cmd.Flags().Changed("port")
+
+			// Alias validation is best-effort: acquire an authenticated client if
+			// we can, but continue (with a warning) when one is unavailable so a
+			// misconfigured or offline client doesn't block getting to a working
+			// local workspace. A definitive conflict/invalid answer still fails.
+			spClient, err := newPluginClient()
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not initialize an authenticated client; alias will not be validated: %v\n", err)
+				spClient = nil
+			}
+
+			deps := initDeps{
+				client:     spClient,
+				in:         cmd.InOrStdin(),
+				out:        cmd.OutOrStdout(),
+				errOut:     cmd.ErrOrStderr(),
+				scaffold:   defaultScaffold,
+				fetchGuide: defaultFetchGuide,
+			}
+			return runInit(context.Background(), deps, opts)
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.name, "name", "", "Plugin display name")
+	cmd.Flags().StringVar(&opts.alias, "alias", "", "Tenant-unique plugin alias (defaults to a slug of the name)")
+	cmd.Flags().StringVar(&opts.path, "path", "", "Attach the SDK to the existing project at this directory instead of scaffolding a new workspace")
+	cmd.Flags().StringVar(&opts.outDir, "out-dir", "", "Build output directory (required when attaching with --path)")
+	cmd.Flags().IntVar(&opts.port, "port", defaultDevServerPort, "Local dev server port (used when attaching with --path)")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "Overwrite plugin files this command manages if they already exist")
+
+	return cmd
+}
+
+// runInit resolves inputs, validates the alias against UMS (before any
+// filesystem mutation), then dispatches to the new-workspace or --path flow.
+// The command runs headless (no prompts) when the required flags for the chosen
+// flow are supplied; otherwise it prompts interactively.
+func runInit(ctx context.Context, deps initDeps, opts initOptions) error {
+	r := bufio.NewReader(deps.in)
+
+	// A provided --name (or positional) is the signal to run headless; without
+	// it we prompt for the missing inputs.
+	interactive := opts.name == ""
+
+	name, err := resolveName(r, deps, opts, interactive)
+	if err != nil {
+		return err
+	}
+	alias, err := resolveAndCheckAlias(ctx, r, deps, opts, name, interactive)
+	if err != nil {
+		return err
+	}
+
+	if opts.path != "" {
+		return runPathAttach(r, deps, opts, name, alias, interactive)
+	}
+	return runNewWorkspace(deps, name, alias)
+}
+
+// runNewWorkspace scaffolds the Angular starter into ./<alias>/ and personalizes
+// it. It hard-fails if the destination already exists.
+func runNewWorkspace(deps initDeps, name, alias string) error {
+	destDir := alias
+	if _, err := os.Stat(destDir); err == nil {
+		return fmt.Errorf("error: project '%s' already exists", destDir)
+	}
+
+	if err := deps.scaffold(destDir); err != nil {
+		// Clean up a partially extracted directory; it did not exist before.
+		_ = os.RemoveAll(destDir)
+		return err
+	}
+
+	if err := personalizeScaffold(destDir, alias, name); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(deps.out, "\nCreated plugin workspace %q.\n\nNext steps:\n  cd %s\n  npm install\n  sail ui-plugins create\n", alias, destDir)
+	return nil
+}
+
+// runPathAttach makes an existing project SDK-ready without touching unrelated
+// files: it generates sp-ui-plugin.json and drops the generic guide, prompting
+// (or honoring --force) before overwriting either file it manages.
+func runPathAttach(r *bufio.Reader, deps initDeps, opts initOptions, name, alias string, interactive bool) error {
+	info, err := os.Stat(opts.path)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("--path %q is not an existing directory", opts.path)
+	}
+
+	outDir, err := resolveOutDir(r, deps, opts, interactive)
+	if err != nil {
+		return err
+	}
+	port, err := resolvePort(r, deps, opts, interactive)
+	if err != nil {
+		return err
+	}
+
+	cfg := generateWorkspaceManifest(alias, name, outDir, port)
+	manifestPath := filepath.Join(opts.path, manifestFileName)
+	if err := writeOwnedFile(r, deps, manifestPath, opts.force, func() error {
+		return writeWorkspaceManifest(manifestPath, cfg)
+	}); err != nil {
+		return err
+	}
+
+	guidePath := filepath.Join(opts.path, genericGuideFileName)
+	if err := writeOwnedFile(r, deps, guidePath, opts.force, func() error {
+		return deps.fetchGuide(guidePath)
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(deps.out, "\nPrepared %q as a UI plugin workspace.\n\nNext steps:\n  Review %s and %s\n  Install @sailpoint/ui-plugin-sdk per the guide\n  sail ui-plugins create\n", opts.path, manifestFileName, genericGuideFileName)
+	return nil
+}
+
+func resolveName(r *bufio.Reader, deps initDeps, opts initOptions, interactive bool) (string, error) {
+	if opts.name != "" {
+		return opts.name, nil
+	}
+	if !interactive {
+		return "", fmt.Errorf("plugin name is required (set --name)")
+	}
+	v, err := promptLine(r, deps.out, "Plugin Name", "")
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(v) == "" {
+		return "", fmt.Errorf("plugin name is required")
+	}
+	return strings.TrimSpace(v), nil
+}
+
+// resolveAndCheckAlias resolves the alias (an --alias value, or a slug of the
+// name) and validates it against UMS. In interactive mode a definitive negative
+// — already taken (409) or invalid (400) — reports why and re-prompts for a new
+// alias (the correctable case) rather than aborting the whole command; headless
+// mode fails fast. An inconclusive check (no client / unreachable) warns and is
+// accepted, matching create's best-effort behavior.
+func resolveAndCheckAlias(ctx context.Context, r *bufio.Reader, deps initDeps, opts initOptions, name string, interactive bool) (string, error) {
+	def := slugifyAlias(name)
+
+	if !interactive {
+		alias := opts.alias
+		if alias == "" {
+			if def == "" {
+				return "", fmt.Errorf("could not derive an alias from %q; set --alias", name)
+			}
+			alias = def
+		}
+		if err := checkAlias(ctx, deps.client, deps.errOut, alias); err != nil {
+			return "", err
+		}
+		return alias, nil
+	}
+
+	// Interactive: on a definitive negative, report why and prompt again. The
+	// attempt cap prevents an infinite loop when stdin is exhausted.
+	alias := opts.alias
+	for attempt := 0; attempt < maxAliasPrompts; attempt++ {
+		if alias == "" {
+			v, err := promptLine(r, deps.out, "Plugin Alias", def)
+			if err != nil {
+				return "", err
+			}
+			alias = strings.TrimSpace(v)
+			if alias == "" {
+				return "", fmt.Errorf("plugin alias is required")
+			}
+		}
+		err := checkAlias(ctx, deps.client, deps.errOut, alias)
+		if err == nil {
+			return alias, nil
+		}
+		fmt.Fprintf(deps.out, "%v — please choose a different alias.\n", err)
+		alias = ""
+	}
+	return "", fmt.Errorf("no valid alias provided after %d attempts", maxAliasPrompts)
+}
+
+func resolveOutDir(r *bufio.Reader, deps initDeps, opts initOptions, interactive bool) (string, error) {
+	outDir := opts.outDir
+	if outDir == "" {
+		if !interactive {
+			return "", fmt.Errorf("--out-dir is required when attaching with --path")
+		}
+		v, err := promptLine(r, deps.out, "Build Output Directory", "")
+		if err != nil {
+			return "", err
+		}
+		outDir = strings.TrimSpace(v)
+	}
+	if outDir == "" {
+		return "", fmt.Errorf("build output directory is required")
+	}
+	// Reject NUL and other control characters — invalid in filesystem paths on
+	// every platform and a sign of a corrupt/mis-pasted value. Existence and
+	// "is this a real build directory" are validated later by update/upload
+	// since the directory may not exist until the build runs.
+	if hasControlChars(outDir) {
+		return "", fmt.Errorf("build output directory contains invalid control characters")
+	}
+	return outDir, nil
+}
+
+// hasControlChars reports whether s contains any control character (including
+// NUL), which are not valid in filesystem paths.
+func hasControlChars(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvePort(r *bufio.Reader, deps initDeps, opts initOptions, interactive bool) (int, error) {
+	if opts.portSet {
+		if opts.port <= 0 {
+			return 0, fmt.Errorf("port must be greater than 0")
+		}
+		return opts.port, nil
+	}
+	if !interactive {
+		return defaultDevServerPort, nil
+	}
+	v, err := promptLine(r, deps.out, "Port", strconv.Itoa(defaultDevServerPort))
+	if err != nil {
+		return 0, err
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil {
+		return 0, fmt.Errorf("port must be a number: %q", strings.TrimSpace(v))
+	}
+	if port <= 0 {
+		return 0, fmt.Errorf("port must be greater than 0")
+	}
+	return port, nil
+}
+
+// writeOwnedFile writes a file init manages, prompting before overwriting an
+// existing one unless --force is set. Files init does not manage are never
+// touched.
+func writeOwnedFile(r *bufio.Reader, deps initDeps, path string, force bool, write func() error) error {
+	if _, err := os.Stat(path); err == nil && !force {
+		overwrite, err := promptYesNoShared(r, deps.out, fmt.Sprintf("%s already exists. Overwrite?", filepath.Base(path)))
+		if err != nil {
+			return err
+		}
+		if !overwrite {
+			fmt.Fprintf(deps.out, "Skipped %s\n", filepath.Base(path))
+			return nil
+		}
+	}
+	return write()
+}
+
+// checkAlias validates the alias against the UMS validate-alias endpoint. A
+// definitive negative — already taken (409) or invalid (400) — fails the
+// command. Any inconclusive result (no client, transport error, or another
+// non-2xx status such as an auth/route problem) is reported as a warning and
+// allowed to continue, so a misconfigured or unreachable backend doesn't block
+// getting to a working local workspace.
+func checkAlias(ctx context.Context, c client.Client, errOut io.Writer, alias string) error {
+	if c == nil {
+		fmt.Fprintf(errOut, "Warning: alias %q was not validated (no authenticated client). %s\n", alias, aliasNotValidatedHint)
+		return nil
+	}
+	url := validateAliasEndpoint + "?alias=" + neturl.QueryEscape(alias)
+	resp, err := c.Get(ctx, url, uiPluginRequestHeaders())
+	if err != nil {
+		fmt.Fprintf(errOut, "Warning: alias %q was not validated (%v). %s\n", alias, err, aliasNotValidatedHint)
+		return nil
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	switch {
+	case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
+		return nil
+	case resp.StatusCode == http.StatusConflict:
+		return fmt.Errorf("alias %q is already in use in this tenant", alias)
+	case resp.StatusCode == http.StatusBadRequest:
+		return fmt.Errorf("alias %q is invalid: %s", alias, umsErrorMessage(body))
+	default:
+		fmt.Fprintf(errOut, "Warning: alias %q could not be validated (status %d): %s. %s\n", alias, resp.StatusCode, umsErrorMessage(body), aliasNotValidatedHint)
+		return nil
+	}
+}
+
+// aliasNotValidatedHint is appended to best-effort validation warnings so the
+// user knows the alias is re-checked later and how to resolve an unexpected miss.
+const aliasNotValidatedHint = "The alias will be checked again by `sail ui-plugins create`; fix your CLI authentication if this is unexpected."
+
+// defaultScaffold fetches the templates repo archive and extracts the Angular
+// starter subtree into destDir (no template substitution — personalization
+// happens afterward).
+func defaultScaffold(destDir string) error {
+	body, err := initialize.FetchArchive(uiPluginTemplatesRepoOwner, uiPluginTemplatesRepoName, uiPluginTemplatesBranch)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+	return initialize.ExtractSubtree(body, destDir, angularStarterSubdir)
+}
+
+// defaultFetchGuide downloads the generic plugin guide from the templates repo
+// and writes it to destPath.
+func defaultFetchGuide(destPath string) error {
+	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", uiPluginTemplatesRepoOwner, uiPluginTemplatesRepoName, uiPluginTemplatesBranch, genericGuideFileName)
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to fetch plugin guide: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch plugin guide: HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read plugin guide: %w", err)
+	}
+	return os.WriteFile(destPath, data, 0644)
+}
+
+func promptLine(r *bufio.Reader, out io.Writer, label, def string) (string, error) {
+	if def != "" {
+		fmt.Fprintf(out, "%s [%s]: ", label, def)
+	} else {
+		fmt.Fprintf(out, "%s: ", label)
+	}
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	v := strings.TrimSpace(line)
+	if v == "" {
+		return def, nil
+	}
+	return v, nil
+}
+
+func promptYesNoShared(r *bufio.Reader, out io.Writer, question string) (bool, error) {
+	fmt.Fprintf(out, "%s [y/N]: ", question)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
 }

--- a/cmd/ui_plugins/init.md
+++ b/cmd/ui_plugins/init.md
@@ -1,0 +1,42 @@
+==Long==
+# Init
+
+Get a UI plugin project to a clean starting point. `init` has two flows on one command:
+
+- **New workspace** (default): scaffolds a new Angular plugin workspace from the SailPoint UI plugin templates into a new directory named after the plugin alias.
+- **Existing workspace** (`--path <dir>`): makes an existing project SDK-ready by generating a valid `sp-ui-plugin.json` and dropping the plugin guide, without touching unrelated files.
+
+## Inputs
+
+`init` prompts for the minimum inputs, each of which has an equivalent flag so the command can run headless in CI/CD. Providing `--name` (or the positional plugin name) skips the interactive prompts.
+
+- **Plugin Name** — the display name (`--name`, or the positional argument).
+- **Plugin Alias** — the tenant-unique key (`--alias`); defaults to a slug of the name. The alias is validated against your tenant immediately and the command fails fast if it is already taken or invalid.
+- **Build Output Directory** — required when attaching with `--path` (`--out-dir`).
+- **Port** — the local dev server port when attaching with `--path` (`--port`, default 3000).
+
+The alias validation requires an authenticated CLI; `init` fails fast if no authenticated client is available.
+
+## What init does not do
+
+`init` does not install dependencies, build, or register the plugin, and it does not modify your `package.json` dependencies. The SDK ships with the template for new workspaces; for `--path` install it per the generated guide. After `init`, run `npm install` and `sail ui-plugins create` yourself.
+====
+
+==Example==
+
+```bash
+# Scaffold a new Angular workspace (interactive prompts for name/alias)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins init
+
+# Scaffold headlessly (no prompts)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins init "My Plugin" --alias my-plugin
+
+# Attach the SDK to an existing project
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins init "My Plugin" \
+  --path ./existing-app --out-dir ./dist/app --port 3000
+
+# Overwrite plugin files init manages if they already exist
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins init "My Plugin" --path ./existing-app --out-dir ./dist/app --force
+```
+
+====

--- a/cmd/ui_plugins/init_scaffold.go
+++ b/cmd/ui_plugins/init_scaffold.go
@@ -1,0 +1,234 @@
+package ui_plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// sentinelName is the placeholder token the Angular starter template ships with.
+// init substitutes it for the plugin's alias (in identifier files) or display
+// name (in human-facing content) during personalization.
+const sentinelName = "starter"
+
+// slugifyAlias derives a filesystem/URL-safe alias suggestion from the plugin
+// name: lowercased, with runs of non-alphanumeric characters collapsed to a
+// single dash and leading/trailing dashes trimmed. It is only a suggestion —
+// UMS is the authority on alias validity (length, uniqueness, etc.).
+func slugifyAlias(name string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, ch := range strings.ToLower(name) {
+		switch {
+		case (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9'):
+			b.WriteRune(ch)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// generateWorkspaceManifest builds a workspace config with the documented
+// defaults for the --path flow.
+//
+// Defaults are built from the typed model here rather than fetched from
+// ui-plugin-templates on purpose: the manifest schema and validator must live
+// in this package anyway (for local validation and the UMS payload), so
+// generating from the model keeps the written file in lockstep with what the
+// CLI accepts. Additionally, besides minimal defaults, this is constructed
+// using user inputs
+func generateWorkspaceManifest(alias, name, outDir string, port int) *uiPluginWorkspaceConfig {
+	p := port
+	return &uiPluginWorkspaceConfig{
+		Version: supportedVersion1,
+		Manifest: uiPluginManifest{
+			Alias:                   alias,
+			Name:                    map[string]string{"en": name},
+			Description:             map[string]string{"en": name},
+			APIScopes:               []string{"sp:scopes:all"},
+			ContentSecurityPolicies: map[string][]string{},
+			PermissionPolicy:        map[string][]string{},
+			IframeAllow:             map[string][]string{},
+			Slots:                   []uiPluginSlot{{SlotID: "full-page"}},
+		},
+		Build: &uiPluginBuildConfig{OutDir: outDir, Port: &p},
+	}
+}
+
+// writeWorkspaceManifest validates cfg with the shared validator, then writes it
+// as indented JSON to path.
+func writeWorkspaceManifest(path string, cfg *uiPluginWorkspaceConfig) error {
+	if err := validateWorkspaceManifest(cfg); err != nil {
+		return fmt.Errorf("generated %s is invalid: %w", manifestFileName, err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to encode %s: %w", manifestFileName, err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0644)
+}
+
+// personalizeScaffold rewrites the freshly extracted starter in place: the
+// build/identity files adopt the alias, the human-facing display strings adopt
+// the plugin name. Identifier substitution is scoped to the three files below —
+// a blanket text replace across the tree is intentionally avoided.
+func personalizeScaffold(destDir, alias, name string) error {
+	if err := renameAngularProject(destDir, alias); err != nil {
+		return err
+	}
+	if err := setPackageName(destDir, alias); err != nil {
+		return err
+	}
+	if err := personalizeManifestFile(destDir, alias, name); err != nil {
+		return err
+	}
+	if err := personalizeDisplayContent(destDir, name); err != nil {
+		return err
+	}
+	return assertNoSentinel(destDir, alias)
+}
+
+// renameAngularProject renames the Angular project in angular.json and rewrites
+// its build target references to the new alias.
+func renameAngularProject(destDir, alias string) error {
+	path := filepath.Join(destDir, "angular.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	content := string(data)
+
+	// The Angular project name is the sole quoted "starter" token (the project
+	// key under "projects"); buildTarget values keep the sentinel followed by a
+	// colon and are handled separately below.
+	projectKey := `"` + sentinelName + `"`
+	if n := strings.Count(content, projectKey); n != 1 {
+		return fmt.Errorf("expected exactly one Angular project key %s in angular.json, found %d", projectKey, n)
+	}
+	content = strings.Replace(content, projectKey, `"`+alias+`"`, 1)
+
+	// buildTarget values use Angular's stable "project:target:configuration"
+	// specifier grammar (the same form `ng run` consumes). Split on ':' and the
+	// leading segment is always the project name, so swapping the "starter:"
+	// prefix renames the reference regardless of the target/configuration names
+	// — robust across Angular versions and independent of angular.json layout.
+	content = strings.ReplaceAll(content, `"`+sentinelName+`:`, `"`+alias+`:`)
+
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func setPackageName(destDir, alias string) error {
+	return replaceExactlyOnce(
+		filepath.Join(destDir, "package.json"),
+		`"name": "`+sentinelName+`"`,
+		`"name": "`+alias+`"`,
+	)
+}
+
+// personalizeManifestFile rewrites the scaffolded sp-ui-plugin.json with the
+// plugin's identity and alias-derived output path, re-validating before writing.
+func personalizeManifestFile(destDir, alias, name string) error {
+	path := filepath.Join(destDir, manifestFileName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	cfg, err := parseWorkspaceManifestStrict(raw)
+	if err != nil {
+		return fmt.Errorf("invalid %s in template: %w", manifestFileName, err)
+	}
+	cfg.Manifest.Alias = alias
+	cfg.Manifest.Name = map[string]string{"en": name}
+	cfg.Manifest.Description = map[string]string{"en": name}
+	if cfg.Build == nil {
+		cfg.Build = &uiPluginBuildConfig{}
+	}
+	cfg.Build.OutDir = "./dist/" + alias + "/browser"
+	return writeWorkspaceManifest(path, cfg)
+}
+
+// personalizeDisplayContent updates the human-facing title strings to the plugin
+// name. app.ts and app.spec.ts are kept in lockstep so the scaffold's unit test
+// still passes; the name is escaped for each file's syntax.
+func personalizeDisplayContent(destDir, name string) error {
+	tsName := escapeSingleQuoted(name)
+	if err := replaceExactlyOnce(
+		filepath.Join(destDir, "src", "app", "app.ts"),
+		"signal('"+sentinelName+"')",
+		"signal('"+tsName+"')",
+	); err != nil {
+		return err
+	}
+	if err := replaceExactlyOnce(
+		filepath.Join(destDir, "src", "app", "app.spec.ts"),
+		"Hello, "+sentinelName,
+		"Hello, "+tsName,
+	); err != nil {
+		return err
+	}
+	// index.html carries the capitalized "Starter" literal in its <title>.
+	return replaceExactlyOnce(
+		filepath.Join(destDir, "src", "index.html"),
+		"<title>Starter</title>",
+		"<title>"+html.EscapeString(name)+"</title>",
+	)
+}
+
+// assertNoSentinel guards against a missed identifier substitution by checking
+// the specific sentinel patterns that must have been rewritten. It intentionally
+// does not scan whole files — the display name legitimately may contain the
+// word — and is a no-op when the alias itself equals the sentinel.
+func assertNoSentinel(destDir, alias string) error {
+	if alias == sentinelName {
+		return nil
+	}
+	checks := []struct{ file, pattern string }{
+		{"angular.json", `"` + sentinelName + `"`},
+		{"angular.json", `"` + sentinelName + `:`},
+		{"package.json", `"name": "` + sentinelName + `"`},
+		{manifestFileName, "dist/" + sentinelName + "/"},
+	}
+	for _, c := range checks {
+		data, err := os.ReadFile(filepath.Join(destDir, c.file))
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(data), c.pattern) {
+			return fmt.Errorf("unexpected %q remaining in %s after personalization", c.pattern, c.file)
+		}
+	}
+	return nil
+}
+
+// replaceExactlyOnce replaces the single expected occurrence of old with new in
+// the file at path, erroring if it is not found exactly once (a guard against
+// template drift).
+func replaceExactlyOnce(path, old, new string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	content := string(data)
+	if n := strings.Count(content, old); n != 1 {
+		return fmt.Errorf("expected exactly one %q in %s, found %d", old, filepath.Base(path), n)
+	}
+	content = strings.Replace(content, old, new, 1)
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// escapeSingleQuoted escapes a value for embedding inside a single-quoted
+// TypeScript/JavaScript string literal.
+func escapeSingleQuoted(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return s
+}

--- a/cmd/ui_plugins/init_test.go
+++ b/cmd/ui_plugins/init_test.go
@@ -1,0 +1,467 @@
+package ui_plugins
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSlugifyAlias(t *testing.T) {
+	cases := map[string]string{
+		"My Plugin":       "my-plugin",
+		"My Plugin!":      "my-plugin",
+		"  Access  Req  ": "access-req",
+		"UPPER_case":      "upper-case",
+		"a--b":            "a-b",
+		"!!!":             "",
+		"café99":          "caf-99",
+	}
+	for in, want := range cases {
+		if got := slugifyAlias(in); got != want {
+			t.Errorf("slugifyAlias(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGenerateWorkspaceManifest_Valid(t *testing.T) {
+	cfg := generateWorkspaceManifest("acme-plugin", "Acme Plugin", "./dist/app", 4200)
+	if err := validateWorkspaceManifest(cfg); err != nil {
+		t.Fatalf("generated manifest failed validation: %v", err)
+	}
+	if cfg.Manifest.Alias != "acme-plugin" {
+		t.Errorf("alias = %q", cfg.Manifest.Alias)
+	}
+	if cfg.Manifest.Name["en"] != "Acme Plugin" || cfg.Manifest.Description["en"] != "Acme Plugin" {
+		t.Errorf("name/description not set from plugin name: %+v", cfg.Manifest)
+	}
+	if cfg.Build == nil || cfg.Build.OutDir != "./dist/app" || cfg.Build.Port == nil || *cfg.Build.Port != 4200 {
+		t.Errorf("build config wrong: %+v", cfg.Build)
+	}
+	if len(cfg.Manifest.Slots) != 1 || cfg.Manifest.Slots[0].SlotID != "full-page" {
+		t.Errorf("slots wrong: %+v", cfg.Manifest.Slots)
+	}
+	// Non-nil empty policy maps satisfy the validator's presence requirement.
+	if cfg.Manifest.ContentSecurityPolicies == nil || cfg.Manifest.PermissionPolicy == nil || cfg.Manifest.IframeAllow == nil {
+		t.Error("policy maps must be non-nil")
+	}
+}
+
+// writeStarterFixture creates a minimal copy of the Angular starter's
+// personalization-relevant files (with the sentinel token) under dir.
+func writeStarterFixture(t *testing.T, dir string) {
+	t.Helper()
+	files := map[string]string{
+		"angular.json": `{
+  "projects": {
+    "starter": {
+      "architect": {
+        "serve": {
+          "configurations": {
+            "production": { "buildTarget": "starter:build:production" },
+            "development": { "buildTarget": "starter:build:development" }
+          }
+        }
+      }
+    }
+  }
+}`,
+		"package.json":        `{` + "\n" + `  "name": "starter",` + "\n" + `  "version": "0.0.0"` + "\n" + `}`,
+		"sp-ui-plugin.json":   `{"version":1,"manifest":{"alias":"","name":{"en":""},"description":{"en":""},"apiScopes":["sp:scopes:all"],"permissionPolicy":{},"iframeAllow":{},"contentSecurityPolicies":{},"slots":[{"slotId":"full-page"}]},"build":{"outDir":"./dist/starter/browser","port":4200}}`,
+		"src/app/app.ts":      "protected readonly title = signal('starter');",
+		"src/app/app.spec.ts": "expect(x).toContain('Hello, starter');",
+		"src/index.html":      "<head><title>Starter</title></head>",
+	}
+	for rel, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+}
+
+func TestPersonalizeScaffold(t *testing.T) {
+	dir := t.TempDir()
+	writeStarterFixture(t, dir)
+
+	if err := personalizeScaffold(dir, "acme-plugin", "O'Brien & Co"); err != nil {
+		t.Fatalf("personalizeScaffold: %v", err)
+	}
+
+	angular := readFile(t, filepath.Join(dir, "angular.json"))
+	if !strings.Contains(angular, `"acme-plugin": {`) {
+		t.Error("angular.json project not renamed")
+	}
+	if !strings.Contains(angular, `"acme-plugin:build:production"`) || !strings.Contains(angular, `"acme-plugin:build:development"`) {
+		t.Error("angular.json buildTargets not rewritten")
+	}
+	if strings.Contains(angular, "starter") {
+		t.Error("angular.json still contains sentinel")
+	}
+
+	pkg := readFile(t, filepath.Join(dir, "package.json"))
+	if !strings.Contains(pkg, `"name": "acme-plugin"`) {
+		t.Error("package.json name not set")
+	}
+
+	// Manifest is re-generated and valid, with identity + alias-derived outDir.
+	raw := readFile(t, filepath.Join(dir, manifestFileName))
+	var cfg uiPluginWorkspaceConfig
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("manifest not valid JSON: %v", err)
+	}
+	if cfg.Manifest.Alias != "acme-plugin" {
+		t.Errorf("manifest alias = %q", cfg.Manifest.Alias)
+	}
+	if cfg.Manifest.Name["en"] != "O'Brien & Co" {
+		t.Errorf("manifest name = %q", cfg.Manifest.Name["en"])
+	}
+	if cfg.Build.OutDir != "./dist/acme-plugin/browser" {
+		t.Errorf("outDir = %q", cfg.Build.OutDir)
+	}
+
+	// Display content uses the (escaped) name and stays in lockstep.
+	appTs := readFile(t, filepath.Join(dir, "src", "app", "app.ts"))
+	appSpec := readFile(t, filepath.Join(dir, "src", "app", "app.spec.ts"))
+	if !strings.Contains(appTs, `signal('O\'Brien & Co')`) {
+		t.Errorf("app.ts not personalized/escaped: %s", appTs)
+	}
+	if !strings.Contains(appSpec, `Hello, O\'Brien & Co`) {
+		t.Errorf("app.spec.ts not personalized/escaped: %s", appSpec)
+	}
+	index := readFile(t, filepath.Join(dir, "src", "index.html"))
+	if !strings.Contains(index, "<title>O&#39;Brien &amp; Co</title>") {
+		t.Errorf("index.html title not HTML-escaped: %s", index)
+	}
+}
+
+func TestPersonalizeScaffold_AliasEqualsSentinel(t *testing.T) {
+	dir := t.TempDir()
+	writeStarterFixture(t, dir)
+	// alias == "starter" is legitimate; the backstop must not trip.
+	if err := personalizeScaffold(dir, "starter", "Starter"); err != nil {
+		t.Fatalf("personalizeScaffold with alias=sentinel: %v", err)
+	}
+}
+
+func TestCheckAlias(t *testing.T) {
+	ctx := context.Background()
+
+	// Definitive negatives fail.
+	conflict := &fakeClient{getStatus: 409}
+	if err := checkAlias(ctx, conflict, &strings.Builder{}, "taken"); err == nil || !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("409 should report conflict, got %v", err)
+	}
+	bad := &fakeClient{getStatus: 400, getBody: `{"message":"too short"}`}
+	if err := checkAlias(ctx, bad, &strings.Builder{}, "ab"); err == nil || !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("400 should report invalid, got %v", err)
+	}
+
+	// Available passes silently.
+	ok := &fakeClient{getStatus: 200}
+	var okWarn strings.Builder
+	if err := checkAlias(ctx, ok, &okWarn, "free-alias"); err != nil {
+		t.Errorf("200 should pass, got %v", err)
+	}
+	if okWarn.Len() != 0 {
+		t.Errorf("200 should not warn, got %q", okWarn.String())
+	}
+
+	// Inconclusive results warn and continue (no error).
+	// nil client:
+	var w1 strings.Builder
+	if err := checkAlias(ctx, nil, &w1, "x"); err != nil {
+		t.Errorf("nil client should not error (best-effort), got %v", err)
+	}
+	if !strings.Contains(w1.String(), "Warning") {
+		t.Errorf("nil client should emit a warning, got %q", w1.String())
+	}
+	// transport error:
+	var w2 strings.Builder
+	if err := checkAlias(ctx, &fakeClient{getErr: errors.New("boom")}, &w2, "x"); err != nil {
+		t.Errorf("transport error should not error (best-effort), got %v", err)
+	}
+	if !strings.Contains(w2.String(), "Warning") {
+		t.Errorf("transport error should emit a warning, got %q", w2.String())
+	}
+	// non-2xx (e.g. forbidden):
+	var w3 strings.Builder
+	if err := checkAlias(ctx, &fakeClient{getStatus: 403}, &w3, "x"); err != nil {
+		t.Errorf("403 should not error (best-effort), got %v", err)
+	}
+	if !strings.Contains(w3.String(), "Warning") {
+		t.Errorf("403 should emit a warning, got %q", w3.String())
+	}
+}
+
+func TestRunInit_PathAttach_Headless(t *testing.T) {
+	target := t.TempDir()
+	// A pre-existing user file must be preserved untouched.
+	userFile := filepath.Join(target, "keep.txt")
+	if err := os.WriteFile(userFile, []byte("original"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	guideFetched := false
+	deps := initDeps{
+		client: &fakeClient{getStatus: 200},
+		in:     strings.NewReader(""),
+		out:    &strings.Builder{},
+		errOut: &strings.Builder{},
+		fetchGuide: func(destPath string) error {
+			guideFetched = true
+			return os.WriteFile(destPath, []byte("guide"), 0644)
+		},
+	}
+	opts := initOptions{name: "My Plugin", path: target, outDir: "./dist/app"}
+
+	if err := runInit(context.Background(), deps, opts); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	// Manifest generated and valid.
+	cfg, err := loadAndValidateWorkspaceManifest(filepath.Join(target, manifestFileName))
+	if err != nil {
+		t.Fatalf("generated manifest invalid: %v", err)
+	}
+	if cfg.Manifest.Alias != "my-plugin" {
+		t.Errorf("alias = %q, want my-plugin (slug default)", cfg.Manifest.Alias)
+	}
+	if cfg.Build.OutDir != "./dist/app" || cfg.Build.Port == nil || *cfg.Build.Port != defaultDevServerPort {
+		t.Errorf("build config = %+v (want outDir ./dist/app, port %d)", cfg.Build, defaultDevServerPort)
+	}
+	if !guideFetched {
+		t.Error("guide was not fetched")
+	}
+	if data, _ := os.ReadFile(userFile); string(data) != "original" {
+		t.Error("pre-existing user file was modified")
+	}
+}
+
+func TestRunInit_AliasConflict_NoMutation(t *testing.T) {
+	target := t.TempDir()
+	deps := initDeps{
+		client:     &fakeClient{getStatus: 409},
+		in:         strings.NewReader(""),
+		out:        &strings.Builder{},
+		errOut:     &strings.Builder{},
+		fetchGuide: func(string) error { return nil },
+	}
+	opts := initOptions{name: "My Plugin", path: target, outDir: "./dist/app"}
+
+	if err := runInit(context.Background(), deps, opts); err == nil {
+		t.Fatal("expected alias-conflict error")
+	}
+	if _, err := os.Stat(filepath.Join(target, manifestFileName)); err == nil {
+		t.Error("manifest must not be written when alias validation fails")
+	}
+}
+
+func TestRunInit_PathMissingOutDir_Headless(t *testing.T) {
+	target := t.TempDir()
+	deps := initDeps{
+		client:     &fakeClient{getStatus: 200},
+		in:         strings.NewReader(""),
+		out:        &strings.Builder{},
+		errOut:     &strings.Builder{},
+		fetchGuide: func(string) error { return nil },
+	}
+	opts := initOptions{name: "My Plugin", path: target} // no out-dir
+
+	if err := runInit(context.Background(), deps, opts); err == nil || !strings.Contains(err.Error(), "out-dir") {
+		t.Fatalf("expected out-dir required error, got %v", err)
+	}
+}
+
+func TestResolveAndCheckAlias_RepromptsOnConflict(t *testing.T) {
+	// Interactive: first alias taken (409), second available (200) → succeeds
+	// with the second, after telling the user why.
+	client := &seqClient{getQueue: []stubResp{{status: 409}, {status: 200}}}
+	r := bufio.NewReader(strings.NewReader("taken\ngood-alias\n"))
+	var out strings.Builder
+	deps := initDeps{client: client, out: &out, errOut: &strings.Builder{}}
+
+	alias, err := resolveAndCheckAlias(context.Background(), r, deps, initOptions{}, "My Plugin", true)
+	if err != nil {
+		t.Fatalf("expected success after re-prompt, got %v", err)
+	}
+	if alias != "good-alias" {
+		t.Errorf("alias = %q, want good-alias", alias)
+	}
+	if !strings.Contains(out.String(), "please choose a different alias") {
+		t.Errorf("expected a re-prompt notice, got %q", out.String())
+	}
+}
+
+func TestResolveAndCheckAlias_HeadlessConflictFailsFast(t *testing.T) {
+	// Headless: a definitive conflict fails immediately (no prompting).
+	client := &seqClient{getQueue: []stubResp{{status: 409}}}
+	deps := initDeps{client: client, out: &strings.Builder{}, errOut: &strings.Builder{}}
+
+	_, err := resolveAndCheckAlias(context.Background(), bufio.NewReader(strings.NewReader("")), deps, initOptions{alias: "taken"}, "My Plugin", false)
+	if err == nil || !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("headless conflict should fail fast, got %v", err)
+	}
+}
+
+func TestResolveAndCheckAlias_EOFBoundsReprompt(t *testing.T) {
+	// Interactive with exhausted stdin: promptLine keeps returning the default,
+	// which stays taken (409), so the loop must be bounded and then error.
+	queue := make([]stubResp, maxAliasPrompts)
+	for i := range queue {
+		queue[i] = stubResp{status: 409}
+	}
+	client := &seqClient{getQueue: queue}
+	deps := initDeps{client: client, out: &strings.Builder{}, errOut: &strings.Builder{}}
+
+	_, err := resolveAndCheckAlias(context.Background(), bufio.NewReader(strings.NewReader("")), deps, initOptions{}, "My Plugin", true)
+	if err == nil || !strings.Contains(err.Error(), "no valid alias") {
+		t.Fatalf("expected bounded re-prompt to error, got %v", err)
+	}
+}
+
+func TestRunInit_PathInconclusiveAlias_Proceeds(t *testing.T) {
+	target := t.TempDir()
+	var errOut strings.Builder
+	deps := initDeps{
+		client:     &fakeClient{getStatus: 403}, // cannot validate (e.g. bad PAT)
+		in:         strings.NewReader(""),
+		out:        &strings.Builder{},
+		errOut:     &errOut,
+		fetchGuide: func(destPath string) error { return os.WriteFile(destPath, []byte("guide"), 0644) },
+	}
+	opts := initOptions{name: "My Plugin", path: target, outDir: "./dist/app"}
+
+	if err := runInit(context.Background(), deps, opts); err != nil {
+		t.Fatalf("inconclusive alias validation should not block init, got: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "Warning") {
+		t.Errorf("expected a validation warning, got %q", errOut.String())
+	}
+	// It proceeded: the manifest was generated.
+	if _, err := loadAndValidateWorkspaceManifest(filepath.Join(target, manifestFileName)); err != nil {
+		t.Errorf("manifest should have been written despite inconclusive validation: %v", err)
+	}
+}
+
+func TestRunInit_PathControlCharsOutDir(t *testing.T) {
+	target := t.TempDir()
+	deps := initDeps{
+		client:     &fakeClient{getStatus: 200},
+		in:         strings.NewReader(""),
+		out:        &strings.Builder{},
+		errOut:     &strings.Builder{},
+		fetchGuide: func(string) error { return nil },
+	}
+	opts := initOptions{name: "My Plugin", path: target, outDir: "dist/\x01app"}
+
+	if err := runInit(context.Background(), deps, opts); err == nil || !strings.Contains(err.Error(), "control characters") {
+		t.Fatalf("expected control-character error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, manifestFileName)); err == nil {
+		t.Error("manifest must not be written when out-dir is invalid")
+	}
+}
+
+func TestRunInit_PathConflict_SkipWithoutForce(t *testing.T) {
+	target := t.TempDir()
+	manifestPath := filepath.Join(target, manifestFileName)
+	if err := os.WriteFile(manifestPath, []byte("preexisting"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	deps := initDeps{
+		client:     &fakeClient{getStatus: 200},
+		in:         strings.NewReader("n\nn\n"), // decline both overwrite prompts
+		out:        &strings.Builder{},
+		errOut:     &strings.Builder{},
+		fetchGuide: func(destPath string) error { return os.WriteFile(destPath, []byte("guide"), 0644) },
+	}
+	opts := initOptions{name: "My Plugin", path: target, outDir: "./dist/app"}
+
+	// Interactive (name empty would prompt); here name is set so headless, but
+	// conflict prompts still read from stdin. Provide "n" to decline.
+	if err := runInit(context.Background(), deps, opts); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	if data, _ := os.ReadFile(manifestPath); string(data) != "preexisting" {
+		t.Error("manifest should be left untouched when overwrite declined")
+	}
+}
+
+func TestScaffoldFlow_PersonalizesFromStub(t *testing.T) {
+	workdir := initTestChdir(t)
+	deps := initDeps{
+		client: &fakeClient{getStatus: 200},
+		in:     strings.NewReader(""),
+		out:    &strings.Builder{},
+		errOut: &strings.Builder{},
+		scaffold: func(destDir string) error {
+			writeStarterFixture(t, destDir)
+			return nil
+		},
+	}
+	opts := initOptions{name: "My Plugin"} // new-workspace, headless; alias slug = my-plugin
+
+	if err := runInit(context.Background(), deps, opts); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	dest := filepath.Join(workdir, "my-plugin")
+	pkg := readFile(t, filepath.Join(dest, "package.json"))
+	if !strings.Contains(pkg, `"name": "my-plugin"`) {
+		t.Errorf("scaffold not personalized: %s", pkg)
+	}
+}
+
+func TestScaffoldFlow_DestExists_HardFail(t *testing.T) {
+	workdir := initTestChdir(t)
+	if err := os.Mkdir(filepath.Join(workdir, "my-plugin"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	scaffoldCalled := false
+	deps := initDeps{
+		client:   &fakeClient{getStatus: 200},
+		in:       strings.NewReader(""),
+		out:      &strings.Builder{},
+		errOut:   &strings.Builder{},
+		scaffold: func(string) error { scaffoldCalled = true; return nil },
+	}
+	opts := initOptions{name: "My Plugin"}
+
+	if err := runInit(context.Background(), deps, opts); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already-exists error, got %v", err)
+	}
+	if scaffoldCalled {
+		t.Error("scaffold must not run when destination already exists")
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func initTestChdir(t *testing.T) string {
+	t.Helper()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	workdir := t.TempDir()
+	if err := os.Chdir(workdir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return workdir
+}

--- a/cmd/ui_plugins/ui_plugins_test.go
+++ b/cmd/ui_plugins/ui_plugins_test.go
@@ -50,11 +50,11 @@ func TestUIPluginsGateEnabled(t *testing.T) {
 func TestUIPluginsStubReachableWhenEnabled(t *testing.T) {
 	t.Setenv(experimentalUIPluginsEnvVar, "1")
 	cmd := NewUIPluginsCommand()
-	cmd.SetArgs([]string{"init"})
+	cmd.SetArgs([]string{"link"})
 
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected init stub command to return not implemented error")
+		t.Fatal("expected link stub command to return not implemented error")
 	}
 
 	if !strings.Contains(err.Error(), "not implemented yet") {

--- a/internal/initialize/fetch.go
+++ b/internal/initialize/fetch.go
@@ -39,18 +39,13 @@ func FetchAndInitProject(repoOwner, repoName, branch, projName string) error {
 		return fmt.Errorf("error: project '%s' already exists", projName)
 	}
 
-	url := fmt.Sprintf("https://github.com/%s/%s/archive/refs/heads/%s.tar.gz", repoOwner, repoName, branch)
-	log.Info("Fetching template from GitHub", "owner", repoOwner, "repo", repoName)
-	resp, err := http.Get(url)
+	body, err := FetchArchive(repoOwner, repoName, branch)
 	if err != nil {
-		return fmt.Errorf("failed to fetch template: %w", err)
+		return err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to fetch template: HTTP %d", resp.StatusCode)
-	}
+	defer body.Close()
 	log.Info("Download complete. Extracting and initializing project...", "project", projName)
-	return ExtractAndInitProject(resp.Body, projName)
+	return ExtractAndInitProject(body, projName)
 }
 
 // ExtractAndInitProject extracts a gzipped tar archive from tarball into projName
@@ -70,71 +65,8 @@ func ExtractAndInitProject(tarball io.Reader, projName string) error {
 	}
 
 	log.Info("Extracting archive", "project", projName)
-	gzr, err := gzip.NewReader(tarball)
-	if err != nil {
-		return fmt.Errorf("failed to read gzip: %w", err)
-	}
-	defer gzr.Close()
-
-	tr := tar.NewReader(gzr)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to read archive: %w", err)
-		}
-
-		name := filepath.FromSlash(hdr.Name)
-		parts := strings.SplitN(name, string(filepath.Separator), 2)
-		if len(parts) < 2 {
-			continue
-		}
-		relPath := parts[1]
-		if relPath == "" {
-			continue
-		}
-		// Reject path traversal (".." components) and absolute paths in archive entry names.
-		if filepath.IsAbs(relPath) {
-			return fmt.Errorf("unsafe path in archive entry %q", hdr.Name)
-		}
-		for _, part := range strings.Split(relPath, string(filepath.Separator)) {
-			if part == ".." {
-				return fmt.Errorf("unsafe path in archive entry %q", hdr.Name)
-			}
-		}
-
-		destPath := filepath.Join(projRoot, relPath)
-		destPath = filepath.Clean(destPath)
-		// Prevent Zip Slip: ensure resolved path stays under projRoot (filepath.Rel is the standard check).
-		relToRoot, relErr := filepath.Rel(projRoot, destPath)
-		if relErr != nil {
-			return fmt.Errorf("unsafe path in archive entry %q: %w", hdr.Name, relErr)
-		}
-		if relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(os.PathSeparator)) {
-			return fmt.Errorf("unsafe path in archive entry %q", hdr.Name)
-		}
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(destPath, 0755); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", destPath, err)
-			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-				return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
-			}
-			f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&0755)
-			if err != nil {
-				return fmt.Errorf("failed to create file %s: %w", destPath, err)
-			}
-			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
-				return fmt.Errorf("failed to write file %s: %w", destPath, err)
-			}
-			f.Close()
-		}
+	if _, err := extractGzipTar(tarball, projRoot, stripArchiveRoot); err != nil {
+		return err
 	}
 
 	log.Info("Applying template substitutions...")
@@ -188,4 +120,169 @@ func applyTemplateFile(filePath, projName string) error {
 		return err
 	}
 	return os.WriteFile(filePath, buf.Bytes(), 0644)
+}
+
+// FetchArchive downloads a GitHub repository branch archive (.tar.gz) and returns
+// the response body for streaming extraction. The caller must Close it. branch
+// defaults to "main" when empty. This is the download half of
+// FetchAndInitProject, factored out so callers can extract a subtree
+// (ExtractSubtree) or otherwise handle the archive themselves.
+func FetchArchive(repoOwner, repoName, branch string) (io.ReadCloser, error) {
+	if repoOwner == "" || repoName == "" {
+		return nil, errors.New("repo owner and name are required")
+	}
+	if branch == "" {
+		branch = defaultBranch
+	}
+	url := fmt.Sprintf("https://github.com/%s/%s/archive/refs/heads/%s.tar.gz", repoOwner, repoName, branch)
+	log.Info("Fetching template from GitHub", "owner", repoOwner, "repo", repoName)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch template: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("failed to fetch template: HTTP %d", resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+// ExtractSubtree extracts only the entries under <archiveRoot>/<subdir>/ from a
+// gzipped tar archive into destDir, stripping both the archive root and the
+// subdir prefix. Unlike ExtractAndInitProject it applies no template
+// substitution: templates that must stay runnable and browsable are
+// personalized by the caller after extraction. It fails if destDir already
+// exists or if the requested subdir is absent from the archive.
+func ExtractSubtree(tarball io.Reader, destDir, subdir string) error {
+	if destDir == "" {
+		return errors.New("destination directory cannot be empty")
+	}
+	if strings.TrimSpace(subdir) == "" {
+		return errors.New("subdir cannot be empty")
+	}
+	if _, err := os.Stat(destDir); err == nil {
+		return fmt.Errorf("error: project '%s' already exists", destDir)
+	}
+
+	destRoot, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve project path: %w", err)
+	}
+
+	// Compare in OS-separator space to match extractGzipTar's entry handling.
+	osSubdir := filepath.Clean(filepath.FromSlash(strings.Trim(subdir, "/")))
+	prefix := osSubdir + string(filepath.Separator)
+
+	// strip keeps only entries under the archive root's <subdir>/ and returns
+	// their path relative to that subdir. The subdir's own directory entry maps
+	// to an empty relPath, which extractGzipTar skips.
+	strip := func(osName string) (string, bool) {
+		parts := strings.SplitN(osName, string(filepath.Separator), 2)
+		if len(parts) < 2 {
+			return "", false
+		}
+		belowRoot := parts[1]
+		if belowRoot == osSubdir {
+			return "", true
+		}
+		if !strings.HasPrefix(belowRoot, prefix) {
+			return "", false
+		}
+		return strings.TrimPrefix(belowRoot, prefix), true
+	}
+
+	log.Info("Extracting subtree", "subdir", subdir, "dest", destDir)
+	written, err := extractGzipTar(tarball, destRoot, strip)
+	if err != nil {
+		return err
+	}
+	if written == 0 {
+		return fmt.Errorf("subdir %q not found in archive", subdir)
+	}
+	log.Info("Subtree extracted.", "dest", destDir)
+	return nil
+}
+
+// stripArchiveRoot removes the single top-level directory component that GitHub
+// archives wrap everything in (e.g. "repo-main/"). It is the default strip used
+// by ExtractAndInitProject.
+func stripArchiveRoot(osName string) (string, bool) {
+	parts := strings.SplitN(osName, string(filepath.Separator), 2)
+	if len(parts) < 2 {
+		return "", false
+	}
+	return parts[1], true
+}
+
+// extractGzipTar streams a gzipped tar archive, applies strip() to each entry to
+// compute its destination-relative path (dropping entries strip rejects or maps
+// to ""), enforces path-traversal / Zip-Slip safety, and writes files and
+// directories under destRoot. It returns the number of entries written so
+// callers can detect an empty/absent selection.
+func extractGzipTar(tarball io.Reader, destRoot string, strip func(osName string) (relPath string, keep bool)) (int, error) {
+	gzr, err := gzip.NewReader(tarball)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read gzip: %w", err)
+	}
+	defer gzr.Close()
+
+	written := 0
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return written, fmt.Errorf("failed to read archive: %w", err)
+		}
+
+		name := filepath.FromSlash(hdr.Name)
+		relPath, keep := strip(name)
+		if !keep || relPath == "" {
+			continue
+		}
+		// Reject path traversal (".." components) and absolute paths in archive entry names.
+		if filepath.IsAbs(relPath) {
+			return written, fmt.Errorf("unsafe path in archive entry %q", hdr.Name)
+		}
+		for _, part := range strings.Split(relPath, string(filepath.Separator)) {
+			if part == ".." {
+				return written, fmt.Errorf("unsafe path in archive entry %q", hdr.Name)
+			}
+		}
+
+		destPath := filepath.Clean(filepath.Join(destRoot, relPath))
+		// Prevent Zip Slip: ensure resolved path stays under destRoot (filepath.Rel is the standard check).
+		relToRoot, relErr := filepath.Rel(destRoot, destPath)
+		if relErr != nil {
+			return written, fmt.Errorf("unsafe path in archive entry %q: %w", hdr.Name, relErr)
+		}
+		if relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(os.PathSeparator)) {
+			return written, fmt.Errorf("unsafe path in archive entry %q", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(destPath, 0755); err != nil {
+				return written, fmt.Errorf("failed to create directory %s: %w", destPath, err)
+			}
+			written++
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+				return written, fmt.Errorf("failed to create directory for %s: %w", destPath, err)
+			}
+			f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&0755)
+			if err != nil {
+				return written, fmt.Errorf("failed to create file %s: %w", destPath, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return written, fmt.Errorf("failed to write file %s: %w", destPath, err)
+			}
+			f.Close()
+			written++
+		}
+	}
+	return written, nil
 }

--- a/internal/initialize/fetch_subtree_test.go
+++ b/internal/initialize/fetch_subtree_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2026, SailPoint Technologies, Inc. All rights reserved.
+package initialize
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const uiTemplatesTarballRoot = "ui-plugin-templates-main"
+
+// tarEntry is a single file or directory to place in a test archive.
+type tarEntry struct {
+	name string // path below the archive root (forward slashes), no trailing slash
+	dir  bool
+	body string
+}
+
+// buildTemplatesTarball builds a gzipped tar archive rooted at
+// uiTemplatesTarballRoot containing the given entries.
+func buildTemplatesTarball(entries []tarEntry) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	root := uiTemplatesTarballRoot + "/"
+	_ = tw.WriteHeader(&tar.Header{Name: root, Typeflag: tar.TypeDir, Mode: 0755})
+	for _, e := range entries {
+		if e.dir {
+			_ = tw.WriteHeader(&tar.Header{Name: root + e.name + "/", Typeflag: tar.TypeDir, Mode: 0755})
+			continue
+		}
+		_ = tw.WriteHeader(&tar.Header{Name: root + e.name, Typeflag: tar.TypeReg, Size: int64(len(e.body)), Mode: 0644})
+		_, _ = tw.Write([]byte(e.body))
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+	return buf.Bytes()
+}
+
+// starterFixtureEntries mirrors the real repo shape: an angular/starter subtree
+// plus siblings that must be ignored (repo-root files, and a starter-extra dir
+// that shares the "starter" prefix but is not under starter/).
+func starterFixtureEntries() []tarEntry {
+	return []tarEntry{
+		{name: "README.md", body: "# root readme"},
+		{name: "SAILPOINT_PLUGIN_GUIDE.md", body: "generic guide"},
+		{name: "angular", dir: true},
+		{name: "angular/starter", dir: true},
+		{name: "angular/starter/package.json", body: `{"name":"starter"}`},
+		{name: "angular/starter/src", dir: true},
+		{name: "angular/starter/src/app", dir: true},
+		{name: "angular/starter/src/app/app.ts", body: "export class App {}"},
+		{name: "angular/starter-extra", dir: true},
+		{name: "angular/starter-extra/notes.md", body: "sibling, must be ignored"},
+	}
+}
+
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	workdir := t.TempDir()
+	if err := os.Chdir(workdir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return workdir
+}
+
+func TestExtractSubtree_StripsPrefixAndIgnoresSiblings(t *testing.T) {
+	workdir := chdirTemp(t)
+	dest := "acme-plugin"
+
+	if err := ExtractSubtree(bytes.NewReader(buildTemplatesTarball(starterFixtureEntries())), dest, "angular/starter"); err != nil {
+		t.Fatalf("ExtractSubtree: %v", err)
+	}
+
+	root := filepath.Join(workdir, dest)
+
+	// Subtree contents land at the destination root, prefix stripped.
+	mustExist(t, filepath.Join(root, "package.json"))
+	mustExist(t, filepath.Join(root, "src", "app", "app.ts"))
+
+	// Repo-root siblings are not extracted.
+	mustNotExist(t, filepath.Join(root, "README.md"))
+	mustNotExist(t, filepath.Join(root, "SAILPOINT_PLUGIN_GUIDE.md"))
+
+	// A sibling that only shares the "starter" prefix is not pulled in.
+	mustNotExist(t, filepath.Join(root, "notes.md"))
+	mustNotExist(t, filepath.Join(root, "starter-extra"))
+
+	// No leftover "angular/" nesting inside the destination.
+	mustNotExist(t, filepath.Join(root, "angular"))
+}
+
+func TestExtractSubtree_MissingSubdir(t *testing.T) {
+	chdirTemp(t)
+	err := ExtractSubtree(bytes.NewReader(buildTemplatesTarball(starterFixtureEntries())), "dest", "react/starter")
+	if err == nil {
+		t.Fatal("expected error for absent subdir")
+	}
+	if !contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found, got: %v", err)
+	}
+}
+
+func TestExtractSubtree_AlreadyExists(t *testing.T) {
+	workdir := chdirTemp(t)
+	dest := "exists"
+	if err := os.Mkdir(filepath.Join(workdir, dest), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := ExtractSubtree(bytes.NewReader(buildTemplatesTarball(starterFixtureEntries())), dest, "angular/starter")
+	if err == nil {
+		t.Fatal("expected error when destination already exists")
+	}
+	if !contains(err.Error(), "already exists") {
+		t.Errorf("error should mention already exists, got: %v", err)
+	}
+}
+
+func TestExtractSubtree_EmptyArgs(t *testing.T) {
+	if err := ExtractSubtree(bytes.NewReader(buildTemplatesTarball(nil)), "", "angular/starter"); err == nil {
+		t.Error("expected error for empty destDir")
+	}
+	if err := ExtractSubtree(bytes.NewReader(buildTemplatesTarball(nil)), "dest", ""); err == nil {
+		t.Error("expected error for empty subdir")
+	}
+}
+
+func TestExtractSubtree_RejectsZipSlip(t *testing.T) {
+	workdir := chdirTemp(t)
+
+	entries := []tarEntry{
+		{name: "angular", dir: true},
+		{name: "angular/starter", dir: true},
+		{name: "angular/starter/../../evil.txt", body: "must not be written"},
+	}
+	err := ExtractSubtree(bytes.NewReader(buildTemplatesTarball(entries)), "dest", "angular/starter")
+	if err == nil {
+		t.Fatal("expected error for path traversal inside subtree")
+	}
+	if !contains(err.Error(), "unsafe path") {
+		t.Errorf("error should mention unsafe path, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(workdir, "evil.txt")); statErr == nil {
+		t.Fatalf("Zip Slip must not create file outside destination")
+	}
+}
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected %s to exist: %v", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("expected %s NOT to exist", path)
+	}
+}
+
+func contains(s, sub string) bool {
+	return bytes.Contains([]byte(s), []byte(sub))
+}


### PR DESCRIPTION
## Description
### What's included
- **Two flows, one command:**
  - **New workspace**: fetches the Angular starter from `sailpoint-oss/ui-plugin-templates` and personalizes it (identifiers → alias, display content → plugin name).
  - **`--path` attach**: non-destructively generates a valid `sp-ui-plugin.json` and drops the plugin guide into an existing project, never touching unrelated files.
- **Fully headless-capable:** every prompt has an equivalent flag, so it runs unattended in CI/CD.
- **Alias handling:** slug default, validated against UMS; best-effort (warns and continues if it can't reach the backend), re-prompts on a taken/invalid alias interactively, fails fast headless.
- **`internal/initialize` refactor:** adds `FetchArchive` + `ExtractSubtree` alongside the existing functions via a shared extraction core. Additive changes with `sail sdk init` behavior unchanged.

### Notable decisions
- No dependency injection, the SDK ships with the template (new) / is installed per the guide (`--path`).
- Angular-only for v1; template ref pinned to `main`.
- Command stays behind the experimental gate (`SAIL_EXPERIMENTAL_UI_PLUGINS=1`).


## How Has This Been Tested?
- New unit coverage for scaffolding/substitution, alias validation + re-prompt, `--path` conflict handling, and subtree extraction.
- All existing `internal/initialize` (SDK-init) tests remain green; `go build ./...`, `go vet`, and `gofmt` clean.
- MV at CSTM-312
