### PR TITLE
CSTM-196: Adding ui-plugins upload command

### DIFF
--- a/cmd/ui_plugins/upload.go
+++ b/cmd/ui_plugins/upload.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"net/http"
 	neturl "net/url"
+	"path"
 	"strings"
 
 	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
 	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -88,7 +90,8 @@ func runUpload(ctx context.Context, c client.Client, manifestPath string, flagOu
 		return mapUMSUploadError(resp.StatusCode, respBody, cfg.Manifest.Alias)
 	}
 
-	return renderUploadSuccess(out, respBody, cfg.Manifest.Alias)
+	viewURL := pluginViewURL(config.GetTenantUrl(), instance.PluginInstanceID)
+	return renderUploadSuccess(out, respBody, cfg.Manifest.Alias, viewURL)
 }
 
 // resolveUploadOutDir determines which build output directory to upload. An
@@ -110,4 +113,17 @@ func resolveUploadOutDir(flagOutDir string, cfg *uiPluginWorkspaceConfig) (strin
 	}
 
 	return outDir, nil
+}
+
+func pluginViewURL(tenantURL, pluginInstanceID string) string {
+	tenantURL = strings.TrimRight(strings.TrimSpace(tenantURL), "/")
+	if tenantURL == "" || pluginInstanceID == "" {
+		return ""
+	}
+	u, err := neturl.Parse(tenantURL)
+	if err != nil {
+		return ""
+	}
+	u.Path = path.Join(u.Path, "ui", "plugin", pluginInstanceID)
+	return u.String()
 }

--- a/cmd/ui_plugins/upload.go
+++ b/cmd/ui_plugins/upload.go
@@ -1,17 +1,113 @@
 package ui_plugins
 
 import (
+	"context"
+	_ "embed"
 	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"strings"
 
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
+//go:embed upload.md
+var uploadHelp string
+
 func newUploadCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "upload",
-		Short: "Upload compiled UI plugin assets",
+	var outDir string
+
+	help := util.ParseHelp(uploadHelp)
+
+	cmd := &cobra.Command{
+		Use:     "upload",
+		Short:   "Upload the already compiled UI plugin assets to the plugin instance",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("`sail ui-plugins upload` is not implemented yet")
+			spClient, err := newPluginClient()
+			if err != nil {
+				return err
+			}
+			return runUpload(context.Background(), spClient, manifestFileName, outDir, cmd.OutOrStdout())
 		},
 	}
+
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "Custom out directory to use instead of sp-ui-plugin.json's build.outDir value")
+
+	return cmd
+}
+
+// runUpload loads the workspace manifest, resolves the build output directory,
+// collects the compiled assets, resolves the plugin instance from the workspace
+// alias, and uploads the assets as a new asset bundle. The client and output
+// writer are injected so the flow is testable without a live tenant.
+func runUpload(ctx context.Context, c client.Client, manifestPath string, flagOutDir string, out io.Writer) error {
+	cfg, err := loadAndValidateWorkspaceManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	outDir, err := resolveUploadOutDir(flagOutDir, cfg)
+	if err != nil {
+		return err
+	}
+
+	files, err := collectUploadFiles(outDir)
+	if err != nil {
+		return err
+	}
+
+	instance, _, err := resolvePluginInstanceByAlias(ctx, c, cfg.Manifest.Alias)
+	if err != nil {
+		return err
+	}
+
+	body, contentType, err := buildAssetBundleBody(files)
+	if err != nil {
+		return err
+	}
+
+	url := pluginInstancesEndpoint + "/" + neturl.PathEscape(instance.PluginInstanceID) + "/asset-bundles"
+	resp, err := c.Post(ctx, url, contentType, body, uiPluginRequestHeaders())
+	if err != nil {
+		return fmt.Errorf("failed to upload plugin assets: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return mapUMSUploadError(resp.StatusCode, respBody, cfg.Manifest.Alias)
+	}
+
+	return renderUploadSuccess(out, respBody, cfg.Manifest.Alias)
+}
+
+// resolveUploadOutDir determines which build output directory to upload. An
+// explicit --out-dir flag takes precedence; otherwise the build.outDir value
+// from the already-loaded workspace manifest is used.
+func resolveUploadOutDir(flagOutDir string, cfg *uiPluginWorkspaceConfig) (string, error) {
+	if trimmed := strings.TrimSpace(flagOutDir); trimmed != "" {
+		return trimmed, nil
+	}
+
+	if cfg.Build == nil {
+		return "", fmt.Errorf("no output directory to upload: pass --out-dir or set build.outDir in %s", manifestFileName)
+	}
+
+	outDir := strings.TrimSpace(cfg.Build.OutDir)
+
+	if outDir == "" {
+		return "", fmt.Errorf("no output directory to upload: pass --out-dir or set build.outDir in %s", manifestFileName)
+	}
+
+	return outDir, nil
 }

--- a/cmd/ui_plugins/upload.md
+++ b/cmd/ui_plugins/upload.md
@@ -1,0 +1,38 @@
+==Long==
+# Upload
+
+Uploads the compiled UI plugin assets from a workspace to its plugin instance in the current tenant. Run this from within an initialized plugin workspace; the alias and configuration are read from `./sp-ui-plugin.json`, and the active tenant is resolved from your CLI authentication.
+
+Uploading is a deploy step, not a build step. The command uploads the assets already present in the build output directory — it never runs your framework's build (e.g. `ng build`) for you. Compile the project with your native tooling first, then upload the result.
+
+## Build output directory
+
+The directory to upload is resolved in this order:
+
+- `--out-dir` when provided.
+- otherwise the `build.outDir` value from `sp-ui-plugin.json`.
+
+If the resolved directory is missing or contains no assets, the command fails fast with a clear error rather than attempting to build the project.
+
+## Deploy target (alias portability)
+
+The workspace `alias` is the deterministic lookup key for the plugin instance, so the same command deploys to whichever tenant your CLI is currently authenticated against — run it in a staging context to update the staging instance, switch context to production and run the identical command to update production. This enables "write once, deploy anywhere" without tracking environment-specific plugin GUIDs locally.
+
+On success the uploaded assets are hosted immutably behind the CDN and become the plugin instance's active asset bundle.
+
+## Output
+
+On success a short confirmation is printed. Backend and packaging failures are surfaced with actionable detail so authors can correct the workspace or retry.
+====
+
+==Example==
+
+```bash
+# Upload the compiled assets from sp-ui-plugin.json's build.outDir
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins upload
+
+# Upload from an explicit directory, overriding build.outDir
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins upload --out-dir ./dist/my-app
+```
+
+====

--- a/cmd/ui_plugins/upload_bundle.go
+++ b/cmd/ui_plugins/upload_bundle.go
@@ -1,0 +1,208 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+ // 100MB CLI guardrail; backend enforces the real limit
+const maxBundleBytes = 100 << 20
+
+// uploadFile is a single compiled asset to include in an asset bundle
+// upload.
+type uploadFile struct {
+	// relPath is the bundle-relative path (forward slashes) sent
+	// as the multipart filename; the backend preserves it as the
+	// asset's path within the bundle.
+	relPath string
+	absPath string
+}
+
+// assetContentTypes maps a lowercase file extension to the single
+// canonical MIME type the UMS asset-bundle endpoint accepts for that
+// extension. The values are bare types (no charset parameter) so they
+// exactly match the backend allowlist; mime.TypeByExtension is
+// deliberately not used because it appends parameters
+// (e.g. "text/javascript; charset=utf-8") that the backend rejects.
+var assetContentTypes = map[string]string{
+	".html":  "text/html",
+	".htm":   "text/html",
+	".js":    "text/javascript",
+	".css":   "text/css",
+	".json":  "application/json",
+	".map":   "application/json",
+	".png":   "image/png",
+	".jpg":   "image/jpeg",
+	".jpeg":  "image/jpeg",
+	".gif":   "image/gif",
+	".svg":   "image/svg+xml",
+	".webp":  "image/webp",
+	".woff":  "font/woff",
+	".woff2": "font/woff2",
+	".ttf":   "font/ttf",
+	".eot":   "application/vnd.ms-fontobject",
+	".ico":   "image/x-icon",
+	".txt":   "text/plain",
+	".pdf":   "application/pdf",
+}
+
+// collectUploadFiles validates the build output directory and gathers
+// the files to upload in a single pass. It fails fast (before any
+// network call) when the directory is missing, is not a directory, or
+// contains no uploadable files.  Dotfiles (e.g. .DS_Store) are
+// skipped, matching the backend, which drops them.
+func collectUploadFiles(root string) ([]uploadFile, error) {
+	stat, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("output directory %s does not exist", root)
+		}
+		return nil, fmt.Errorf("cannot access output directory %s: %w", root, err)
+	}
+	if !stat.IsDir() {
+		return nil, fmt.Errorf("output path %s is not a directory", root)
+	}
+
+	var totalSize int64
+	var errBundleTooLarge = errors.New("bundle exceeds upload guardrail")
+	var files []uploadFile
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasPrefix(d.Name(), ".") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		totalSize += info.Size()
+		if totalSize > maxBundleBytes {
+			return errBundleTooLarge
+		}
+		files = append(files, uploadFile{relPath: filepath.ToSlash(rel), absPath: path})
+		return nil
+	})
+	if errors.Is(err, errBundleTooLarge) {
+		return nil, fmt.Errorf("output directory %s exceeds the %d MB upload guardrail", root, maxBundleBytes>>20)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read output directory %s: %w", root, err)
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("output directory %s contains no files to upload", root)
+	}
+
+	return files, nil
+}
+
+// contentTypeForPath returns the canonical MIME type for the file's
+// extension, falling back to application/octet-stream for
+// unrecognized extensions (which the backend rejects with an
+// actionable message).
+func contentTypeForPath(path string) string {
+	if ct, ok := assetContentTypes[strings.ToLower(filepath.Ext(path))]; ok {
+		return ct
+	}
+	return "application/octet-stream"
+}
+
+var multipartQuoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+// buildAssetBundleBody encodes the files as a multipart/form-data
+// body where each file is a part named "file" whose filename is the
+// bundle-relative path and whose Content-Type matches the
+// extension. It returns the body and the full content type (including
+// the multipart boundary) to send as the request Content-Type.
+func buildAssetBundleBody(files []uploadFile) (io.Reader, string, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	for _, f := range files {
+		data, err := os.ReadFile(f.absPath)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read %s: %w", f.relPath, err)
+		}
+
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, multipartQuoteEscaper.Replace(f.relPath)))
+		header.Set("Content-Type", contentTypeForPath(f.relPath))
+
+		part, err := w.CreatePart(header)
+		if err != nil {
+			return nil, "", err
+		}
+		if _, err := part.Write(data); err != nil {
+			return nil, "", err
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+
+	return &buf, w.FormDataContentType(), nil
+}
+
+// assetBundleResponse is the subset of the UMS asset-bundle response used to
+// render a success summary.
+type assetBundleResponse struct {
+	AssetBundleID string `json:"assetBundleId"`
+	Assets        []struct {
+		Path string `json:"path"`
+	} `json:"assets"`
+}
+
+// renderUploadSuccess prints a human-readable confirmation of the
+// uploaded bundle.
+func renderUploadSuccess(w io.Writer, body []byte, alias string) error {
+	var parsed assetBundleResponse
+	_ = json.Unmarshal(body, &parsed)
+
+	if parsed.AssetBundleID != "" {
+		_, _ = fmt.Fprintf(w, "Uploaded %d asset(s) to plugin %q (bundle %s)\n", len(parsed.Assets), alias, parsed.AssetBundleID)
+	} else {
+		_, _ = fmt.Fprintf(w, "Uploaded assets to plugin %q\n", alias)
+	}
+	return nil
+}
+
+// mapUMSUploadError translates a non-2xx asset-bundle upload response
+// into an actionable error, surfacing the message returned by the
+// backend.
+func mapUMSUploadError(status int, body []byte, alias string) error {
+	message := umsErrorMessage(body)
+
+	switch status {
+	case http.StatusBadRequest:
+		return fmt.Errorf("invalid asset bundle for plugin %q: %s", alias, message)
+	case http.StatusForbidden:
+		return fmt.Errorf("not authorized to upload UI plugin assets (requires the idn:plugins-ui:update right): %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("plugin instance for alias %q not found, or the UI plugins feature is not enabled for this tenant: %s", alias, message)
+	case http.StatusRequestEntityTooLarge:
+		return fmt.Errorf("asset bundle for plugin %q exceeds the maximum allowed size: %s", alias, message)
+	default:
+		return fmt.Errorf("failed to upload plugin assets (status %d): %s", status, message)
+	}
+}

--- a/cmd/ui_plugins/upload_bundle.go
+++ b/cmd/ui_plugins/upload_bundle.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
- // 100MB CLI guardrail; backend enforces the real limit
+// 100MB CLI guardrail; backend enforces the real limit
 const maxBundleBytes = 100 << 20
 
 // uploadFile is a single compiled asset to include in an asset bundle
@@ -175,7 +175,7 @@ type assetBundleResponse struct {
 
 // renderUploadSuccess prints a human-readable confirmation of the
 // uploaded bundle.
-func renderUploadSuccess(w io.Writer, body []byte, alias string) error {
+func renderUploadSuccess(w io.Writer, body []byte, alias string, pluginURL string) error {
 	var parsed assetBundleResponse
 	_ = json.Unmarshal(body, &parsed)
 
@@ -183,6 +183,10 @@ func renderUploadSuccess(w io.Writer, body []byte, alias string) error {
 		_, _ = fmt.Fprintf(w, "Uploaded %d asset(s) to plugin %q (bundle %s)\n", len(parsed.Assets), alias, parsed.AssetBundleID)
 	} else {
 		_, _ = fmt.Fprintf(w, "Uploaded assets to plugin %q\n", alias)
+	}
+
+	if pluginURL != "" {
+		_, _ = fmt.Fprintf(w, "The plugin can be viewed at:\n%s\n", pluginURL)
 	}
 	return nil
 }

--- a/cmd/ui_plugins/upload_bundle_test.go
+++ b/cmd/ui_plugins/upload_bundle_test.go
@@ -1,0 +1,266 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newOutDir creates a temporary directory populated with the given
+// forward-slash-relative files and returns its path.
+func newOutDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, content := range files {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	return dir
+}
+
+func TestCollectUploadFiles(t *testing.T) {
+	t.Run("missing directory", func(t *testing.T) {
+		_, err := collectUploadFiles(filepath.Join(t.TempDir(), "nope"))
+		if err == nil || !strings.Contains(err.Error(), "does not exist") {
+			t.Fatalf("expected does-not-exist error, got: %v", err)
+		}
+	})
+
+	t.Run("path is not a directory", func(t *testing.T) {
+		dir := newOutDir(t, map[string]string{"index.html": "x"})
+		_, err := collectUploadFiles(filepath.Join(dir, "index.html"))
+		if err == nil || !strings.Contains(err.Error(), "is not a directory") {
+			t.Fatalf("expected not-a-directory error, got: %v", err)
+		}
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		_, err := collectUploadFiles(t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "no files to upload") {
+			t.Fatalf("expected empty-directory error, got: %v", err)
+		}
+	})
+
+	t.Run("only dotfiles", func(t *testing.T) {
+		dir := newOutDir(t, map[string]string{".DS_Store": "junk"})
+		_, err := collectUploadFiles(dir)
+		if err == nil || !strings.Contains(err.Error(), "no files to upload") {
+			t.Fatalf("expected empty-after-dotfile-skip error, got: %v", err)
+		}
+	})
+
+	t.Run("collects nested files and skips dotfiles", func(t *testing.T) {
+		dir := newOutDir(t, map[string]string{
+			"index.html":          "<html>",
+			"assets/app.js":       "console.log(1)",
+			"assets/img/logo.png": "PNG",
+			".DS_Store":           "junk",
+			"assets/.hidden":      "secret",
+		})
+
+		files, err := collectUploadFiles(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := map[string]bool{}
+		for _, f := range files {
+			got[f.relPath] = true
+		}
+		want := []string{"index.html", "assets/app.js", "assets/img/logo.png"}
+		if len(got) != len(want) {
+			t.Fatalf("expected %d files, got %d: %v", len(want), len(got), got)
+		}
+		for _, w := range want {
+			if !got[w] {
+				t.Fatalf("expected %q among collected files, got: %v", w, got)
+			}
+		}
+		if got[".DS_Store"] || got["assets/.hidden"] {
+			t.Fatalf("dotfiles should be skipped, got: %v", got)
+		}
+	})
+
+	t.Run("exceeds size guardrail", func(t *testing.T) {
+		dir := t.TempDir()
+		f, err := os.Create(filepath.Join(dir, "big.js"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Sparse file: sets the reported size without writing the bytes.
+		if err := f.Truncate(maxBundleBytes + 1); err != nil {
+			f.Close()
+			t.Fatal(err)
+		}
+		f.Close()
+
+		_, err = collectUploadFiles(dir)
+		if err == nil || !strings.Contains(err.Error(), "guardrail") {
+			t.Fatalf("expected size-guardrail error, got: %v", err)
+		}
+	})
+}
+
+func TestContentTypeForPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"index.html", "text/html"},
+		{"main.js", "text/javascript"},
+		{"styles.css", "text/css"},
+		{"data.json", "application/json"},
+		{"main.js.map", "application/json"},
+		{"logo.PNG", "image/png"},
+		{"font.woff2", "font/woff2"},
+		{"favicon.ico", "image/x-icon"},
+		{"archive.zip", "application/octet-stream"},
+		{"noext", "application/octet-stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := contentTypeForPath(tt.path); got != tt.want {
+				t.Fatalf("contentTypeForPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildAssetBundleBody(t *testing.T) {
+	dir := newOutDir(t, map[string]string{
+		"index.html":    "<html></html>",
+		"assets/app.js": "console.log(1)",
+	})
+	files := []uploadFile{
+		{relPath: "index.html", absPath: filepath.Join(dir, "index.html")},
+		{relPath: "assets/app.js", absPath: filepath.Join(dir, "assets", "app.js")},
+	}
+
+	body, contentType, err := buildAssetBundleBody(files)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(contentType, "multipart/form-data; boundary=") {
+		t.Fatalf("unexpected content type: %s", contentType)
+	}
+
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("failed to parse content type: %v", err)
+	}
+
+	mr := multipart.NewReader(body, params["boundary"])
+	foundIndex, foundApp := false, false
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading part: %v", err)
+		}
+
+		disposition := p.Header.Get("Content-Disposition")
+		if !strings.Contains(disposition, `name="file"`) {
+			t.Fatalf("expected form field name 'file', got disposition %q", disposition)
+		}
+		data, _ := io.ReadAll(p)
+
+		switch {
+		// The subdirectory is preserved on the wire (the backend uses
+		// preservePath); Go's Part.FileName would strip it, so assert the raw
+		// Content-Disposition instead.
+		case strings.Contains(disposition, `filename="index.html"`):
+			foundIndex = true
+			if ct := p.Header.Get("Content-Type"); ct != "text/html" {
+				t.Fatalf("index.html content type = %q, want text/html", ct)
+			}
+			if string(data) != "<html></html>" {
+				t.Fatalf("index.html content = %q", data)
+			}
+		case strings.Contains(disposition, `filename="assets/app.js"`):
+			foundApp = true
+			if ct := p.Header.Get("Content-Type"); ct != "text/javascript" {
+				t.Fatalf("app.js content type = %q, want text/javascript", ct)
+			}
+			if string(data) != "console.log(1)" {
+				t.Fatalf("app.js content = %q", data)
+			}
+		default:
+			t.Fatalf("unexpected part disposition: %q", disposition)
+		}
+	}
+
+	if !foundIndex || !foundApp {
+		t.Fatalf("missing expected parts: index=%v app=%v", foundIndex, foundApp)
+	}
+}
+
+func TestBuildAssetBundleBody_ReadError(t *testing.T) {
+	files := []uploadFile{{relPath: "missing.js", absPath: filepath.Join(t.TempDir(), "missing.js")}}
+
+	_, _, err := buildAssetBundleBody(files)
+	if err == nil || !strings.Contains(err.Error(), "failed to read") {
+		t.Fatalf("expected a read error, got: %v", err)
+	}
+}
+
+func TestRenderUploadSuccess(t *testing.T) {
+	t.Run("with bundle id and asset count", func(t *testing.T) {
+		var out bytes.Buffer
+		_ = renderUploadSuccess(&out, []byte(`{"assetBundleId":"ab-9","assets":[{"path":"index.html"},{"path":"app.js"}]}`), "my-plugin", "")
+		got := out.String()
+		for _, want := range []string{"ab-9", "my-plugin", "2 asset"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected %q in output, got: %s", want, got)
+			}
+		}
+	})
+
+	t.Run("without bundle id uses fallback line", func(t *testing.T) {
+		var out bytes.Buffer
+		_ = renderUploadSuccess(&out, []byte(`{}`), "my-plugin", "")
+		got := out.String()
+		if !strings.Contains(got, "Uploaded assets to plugin") || !strings.Contains(got, "my-plugin") {
+			t.Fatalf("expected fallback summary, got: %s", got)
+		}
+	})
+}
+
+func TestMapUMSUploadError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{name: "bad request", status: 400, body: `{"message":"Bundle must include index.html at the root"}`, want: "invalid asset bundle"},
+		{name: "forbidden", status: 403, body: `{"message":"Forbidden"}`, want: "not authorized"},
+		{name: "not found", status: 404, body: `{"message":"Not Found"}`, want: "not found"},
+		{name: "payload too large", status: 413, body: `{"message":"too big"}`, want: "exceeds the maximum allowed size"},
+		{name: "server error", status: 500, body: `{"message":"boom"}`, want: "status 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mapUMSUploadError(tt.status, []byte(tt.body), "my-plugin")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error to contain %q, got: %v", tt.want, err)
+			}
+		})
+	}
+}

--- a/cmd/ui_plugins/upload_test.go
+++ b/cmd/ui_plugins/upload_test.go
@@ -1,0 +1,264 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPluginViewURL(t *testing.T) {
+	const id = "2c918084-8bce-1f2a-0181-abc123def456"
+
+	tests := []struct {
+		name       string
+		tenantURL  string
+		instanceID string
+		want       string
+	}{
+		{
+			name:       "builds view url",
+			tenantURL:  "https://tenant.example.com",
+			instanceID: id,
+			want:       "https://tenant.example.com/ui/plugin/" + id,
+		},
+		{
+			name:       "trims trailing slash",
+			tenantURL:  "https://tenant.example.com/",
+			instanceID: id,
+			want:       "https://tenant.example.com/ui/plugin/" + id,
+		},
+		{
+			name:       "trims surrounding whitespace",
+			tenantURL:  "  https://tenant.example.com  ",
+			instanceID: id,
+			want:       "https://tenant.example.com/ui/plugin/" + id,
+		},
+		{
+			name:       "preserves existing base path",
+			tenantURL:  "https://tenant.example.com/base",
+			instanceID: id,
+			want:       "https://tenant.example.com/base/ui/plugin/" + id,
+		},
+		{
+			name:       "empty tenant url yields empty string",
+			tenantURL:  "",
+			instanceID: id,
+			want:       "",
+		},
+		{
+			name:       "whitespace-only tenant url yields empty string",
+			tenantURL:  "   ",
+			instanceID: id,
+			want:       "",
+		},
+		{
+			name:       "empty instance id yields empty string",
+			tenantURL:  "https://tenant.example.com",
+			instanceID: "",
+			want:       "",
+		},
+		{
+			name:       "unparseable tenant url yields empty string",
+			tenantURL:  "https://exa\x7fmple.com",
+			instanceID: id,
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pluginViewURL(tt.tenantURL, tt.instanceID); got != tt.want {
+				t.Fatalf("pluginViewURL(%q, %q) = %q, want %q", tt.tenantURL, tt.instanceID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveUploadOutDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		cfg     *uiPluginWorkspaceConfig
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "flag takes precedence over build.outDir",
+			flag: "custom-dist",
+			cfg:  &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{OutDir: "dist"}},
+			want: "custom-dist",
+		},
+		{
+			name: "flag is trimmed",
+			flag: "  custom-dist  ",
+			cfg:  &uiPluginWorkspaceConfig{},
+			want: "custom-dist",
+		},
+		{
+			name: "falls back to build.outDir",
+			flag: "",
+			cfg:  &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{OutDir: "dist"}},
+			want: "dist",
+		},
+		{
+			name: "build.outDir is trimmed",
+			flag: "",
+			cfg:  &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{OutDir: "  dist  "}},
+			want: "dist",
+		},
+		{
+			name: "whitespace-only flag falls back to build.outDir",
+			flag: "   ",
+			cfg:  &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{OutDir: "dist"}},
+			want: "dist",
+		},
+		{
+			name:    "nil build without flag errors",
+			flag:    "",
+			cfg:     &uiPluginWorkspaceConfig{},
+			wantErr: true,
+		},
+		{
+			name:    "empty build.outDir without flag errors",
+			flag:    "",
+			cfg:     &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{OutDir: "  "}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveUploadOutDir(tt.flag, tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got result %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveUploadOutDir(%q) = %q, want %q", tt.flag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunUpload_Success(t *testing.T) {
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   `{"pluginInstanceId":"pi-123","alias":"access-request-plugin"}`,
+		status:    http.StatusCreated,
+		body:      `{"assetBundleId":"ab-1","pluginInstanceId":"pi-123","assets":[{"path":"index.html"}]}`,
+	}
+	outDir := newOutDir(t, map[string]string{"index.html": "<html></html>"})
+	var out bytes.Buffer
+
+	err := runUpload(context.Background(), fc, tempManifestPath(t, testManifestJSON), outDir, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fc.getCalls != 1 {
+		t.Fatalf("expected exactly one Get (resolve-alias), got %d", fc.getCalls)
+	}
+	if fc.postCalls != 1 {
+		t.Fatalf("expected exactly one Post (upload), got %d", fc.postCalls)
+	}
+	wantURL := pluginInstancesEndpoint + "/pi-123/asset-bundles"
+	if fc.gotURL != wantURL {
+		t.Fatalf("expected POST to %s, got %s", wantURL, fc.gotURL)
+	}
+	if fc.gotPostHeaders[experimentalHeader] != "true" {
+		t.Fatalf("expected %s header on upload, got: %v", experimentalHeader, fc.gotPostHeaders)
+	}
+	if !strings.Contains(string(fc.gotBody), "index.html") {
+		t.Fatalf("expected multipart body to include the asset filename, got: %s", fc.gotBody)
+	}
+	if got := out.String(); !strings.Contains(got, "ab-1") || !strings.Contains(got, "access-request-plugin") {
+		t.Fatalf("expected success summary with bundle id and alias, got: %s", got)
+	}
+}
+
+func TestRunUpload_InvalidManifestSkipsClient(t *testing.T) {
+	fc := &fakeClient{}
+
+	err := runUpload(context.Background(), fc, tempManifestPath(t, `{"version":1}`), "somewhere", io.Discard)
+	if err == nil {
+		t.Fatal("expected an error for an invalid manifest")
+	}
+	if fc.getCalls != 0 || fc.postCalls != 0 {
+		t.Fatalf("expected no client calls, got get=%d post=%d", fc.getCalls, fc.postCalls)
+	}
+}
+
+func TestRunUpload_MissingOutDirSkipsClient(t *testing.T) {
+	fc := &fakeClient{}
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	err := runUpload(context.Background(), fc, tempManifestPath(t, testManifestJSON), missing, io.Discard)
+	if err == nil {
+		t.Fatal("expected an error for a missing output directory")
+	}
+	if fc.getCalls != 0 || fc.postCalls != 0 {
+		t.Fatalf("expected no client calls, got get=%d post=%d", fc.getCalls, fc.postCalls)
+	}
+}
+
+func TestRunUpload_AliasResolutionErrorSkipsUpload(t *testing.T) {
+	fc := &fakeClient{getStatus: http.StatusNotFound, getBody: `{"message":"not found"}`}
+	outDir := newOutDir(t, map[string]string{"index.html": "x"})
+
+	err := runUpload(context.Background(), fc, tempManifestPath(t, testManifestJSON), outDir, io.Discard)
+	if err == nil {
+		t.Fatal("expected an error when alias resolution fails")
+	}
+	if fc.postCalls != 0 {
+		t.Fatalf("expected no upload after alias resolution failure, got %d", fc.postCalls)
+	}
+}
+
+func TestRunUpload_UploadErrorMapped(t *testing.T) {
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   `{"pluginInstanceId":"pi-123","alias":"access-request-plugin"}`,
+		status:    http.StatusBadRequest,
+		body:      `{"message":"Bundle must include index.html at the root"}`,
+	}
+	outDir := newOutDir(t, map[string]string{"index.html": "x"})
+	var out bytes.Buffer
+
+	err := runUpload(context.Background(), fc, tempManifestPath(t, testManifestJSON), outDir, &out)
+	if err == nil {
+		t.Fatal("expected an error for a 400 upload response")
+	}
+	if !strings.Contains(err.Error(), "invalid asset bundle") {
+		t.Fatalf("expected mapped upload error, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no success output on error, got: %s", out.String())
+	}
+}
+
+func TestRunUpload_TransportError(t *testing.T) {
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   `{"pluginInstanceId":"pi-123","alias":"access-request-plugin"}`,
+		postErr:   errors.New("boom"),
+	}
+	outDir := newOutDir(t, map[string]string{"index.html": "x"})
+
+	err := runUpload(context.Background(), fc, tempManifestPath(t, testManifestJSON), outDir, io.Discard)
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if !strings.Contains(err.Error(), "failed to upload plugin assets") {
+		t.Fatalf("expected upload transport error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Description
This PR adds the `upload` command to the ui-plugins command group. It allows for an optional out-dir otherwise defaults to the sp-ui-plugin.json `build.outDir` path.

## How Has This Been Tested?
Unit tests have been added and manual testing described in MV ticket CSTM-328