### PR TITLE
CSTM-194: Adding link and unlink commands to ui-plugins

### DIFF
--- a/cmd/ui_plugins/init.go
+++ b/cmd/ui_plugins/init.go
@@ -29,7 +29,7 @@ const (
 	uiPluginTemplatesBranch    = "main"
 	angularStarterSubdir       = "angular/starter"
 	genericGuideFileName       = "SAILPOINT_PLUGIN_GUIDE.md"
-	defaultDevServerPort       = 3000
+	defaultDevServerPort       = 4200
 
 	// maxAliasPrompts bounds the interactive re-prompt loop so exhausted stdin
 	// (EOF) can't spin it forever.
@@ -298,8 +298,8 @@ func hasControlChars(s string) bool {
 
 func resolvePort(r *bufio.Reader, deps initDeps, opts initOptions, interactive bool) (int, error) {
 	if opts.portSet {
-		if opts.port <= 0 {
-			return 0, fmt.Errorf("port must be greater than 0")
+		if portErr := validatePortNumber(opts.port); portErr != nil {
+			return 0, portErr
 		}
 		return opts.port, nil
 	}
@@ -314,10 +314,17 @@ func resolvePort(r *bufio.Reader, deps initDeps, opts initOptions, interactive b
 	if err != nil {
 		return 0, fmt.Errorf("port must be a number: %q", strings.TrimSpace(v))
 	}
-	if port <= 0 {
-		return 0, fmt.Errorf("port must be greater than 0")
+	if portErr := validatePortNumber(port); portErr != nil {
+		return 0, portErr
 	}
 	return port, nil
+}
+
+func validatePortNumber(port int) error {
+	if port <= 0 {
+		return fmt.Errorf("port must be greater than 0")
+	}
+	return nil
 }
 
 // writeOwnedFile writes a file init manages, prompting before overwriting an

--- a/cmd/ui_plugins/init.md
+++ b/cmd/ui_plugins/init.md
@@ -13,7 +13,7 @@ Get a UI plugin project to a clean starting point. `init` has two flows on one c
 - **Plugin Name** — the display name (`--name`, or the positional argument).
 - **Plugin Alias** — the tenant-unique key (`--alias`); defaults to a slug of the name. The alias is validated against your tenant immediately and the command fails fast if it is already taken or invalid.
 - **Build Output Directory** — required when attaching with `--path` (`--out-dir`).
-- **Port** — the local dev server port when attaching with `--path` (`--port`, default 3000).
+- **Port** — the local dev server port when attaching with `--path` (`--port`, default 4200).
 
 The alias validation requires an authenticated CLI; `init` fails fast if no authenticated client is available.
 
@@ -33,7 +33,7 @@ SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins init "My Plugin" --alias my-plugi
 
 # Attach the SDK to an existing project
 SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins init "My Plugin" \
-  --path ./existing-app --out-dir ./dist/app --port 3000
+  --path ./existing-app --out-dir ./dist/app --port 4200
 
 # Overwrite plugin files init manages if they already exist
 SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins init "My Plugin" --path ./existing-app --out-dir ./dist/app --force

--- a/cmd/ui_plugins/link.go
+++ b/cmd/ui_plugins/link.go
@@ -1,17 +1,124 @@
 package ui_plugins
 
 import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
 
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
+//go:embed link.md
+var linkHelp string
+
+type linkRequest struct {
+	Port int `json:"port"`
+}
+
 func newLinkCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "link",
-		Short: "Link local development URL for a UI plugin",
+	var port int
+
+	help := util.ParseHelp(linkHelp)
+	cmd := &cobra.Command{
+		Use:     "link",
+		Short:   "Link local development URL for a UI plugin",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("`sail ui-plugins link` is not implemented yet")
+			spClient, err := newPluginClient()
+			if err != nil {
+				return err
+			}
+			return link(context.Background(), spClient, manifestFileName, port, cmd.Flags().Changed("port"), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
+	cmd.Flags().IntVar(&port, "port", 0, "Custom port to use instead of sp-ui-plugin.json's build.port value")
+
+	return cmd
+}
+
+func link(ctx context.Context, c client.Client, manifestPath string, flagPort int, portSet bool, out io.Writer, errOut io.Writer) error {
+	cfg, err := loadAndValidateWorkspaceManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	tenantUrl := config.GetTenantUrl()
+	if tenantUrl == "" {
+		return fmt.Errorf("no tenant URL configured; run `sail env` to set one before linking")
+	}
+
+	resolvedPort, defaulted, err := resolveLinkPort(flagPort, portSet, cfg)
+	if err != nil {
+		return err
+	}
+
+	if defaulted {
+		fmt.Fprintf(errOut, "no port provided via --port or build.port in %s; defaulting to port %d\n", manifestFileName, defaultDevServerPort)
+	}
+
+	portData := linkRequest{Port: resolvedPort}
+	jsonPortData, err := json.Marshal(portData)
+	if err != nil {
+		return fmt.Errorf("failed to encode port data: %w", err)
+	}
+
+	instance, _, err := resolvePluginInstanceByAlias(ctx, c, cfg.Manifest.Alias)
+	if err != nil {
+		return err
+	}
+
+	url := pluginInstancesEndpoint + "/" + neturl.PathEscape(instance.PluginInstanceID) + "/link"
+	resp, err := c.Post(ctx, url, "application/json", bytes.NewBuffer(jsonPortData), uiPluginRequestHeaders())
+	if err != nil {
+		return fmt.Errorf("failed to create link: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// The response body is read only to explain a failure. The success
+		// path intentionally ignores it so this command does not depend on
+		// the link endpoint's response shape.
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unable to create link: %s", umsErrorMessage(respBody))
+	}
+
+	viewURL := pluginViewURL(tenantUrl, instance.PluginInstanceID)
+	if viewURL == "" {
+		return fmt.Errorf("could not construct developer URL for alias %q", instance.Alias)
+	}
+
+	fmt.Fprintf(errOut, "Plugin %s linked to port %d\nTo load your local plugin in ISC navigate to:\n", instance.Alias, resolvedPort)
+	fmt.Fprintf(out, "%s?spPluginDev=%s\n", viewURL, neturl.QueryEscape(instance.Alias))
+
+	return nil
+}
+
+func resolveLinkPort(flagPort int, portSet bool, cfg *uiPluginWorkspaceConfig) (port int, defaulted bool, err error) {
+	if portSet {
+		if err := validatePortNumber(flagPort); err != nil {
+			return 0, false, fmt.Errorf("provided port is invalid: %w", err)
+		}
+
+		return flagPort, false, nil
+	}
+
+	if cfg.Build == nil || cfg.Build.Port == nil {
+		return defaultDevServerPort, true, nil
+	}
+
+	if err := validatePortNumber(*cfg.Build.Port); err != nil {
+		return 0, false, fmt.Errorf("build.port in %s is invalid: %w", manifestFileName, err)
+	}
+
+	return *cfg.Build.Port, false, nil
 }

--- a/cmd/ui_plugins/link.md
+++ b/cmd/ui_plugins/link.md
@@ -1,0 +1,37 @@
+==Long==
+# Link
+
+Registers your local development server with a UI plugin instance so ISC loads your local code in the live tenant. Run this from within an initialized plugin workspace; the alias is read from `./sp-ui-plugin.json`, and the active tenant is resolved from your CLI authentication.
+
+Linking binds your local dev server port to your own identity on the plugin instance (a per-developer override). It does not affect other developers or the plugin's deployed assets — it only changes what *you* see when you open the developer URL in ISC.
+
+## Port resolution
+
+The port registered as your local dev server is resolved in this order:
+
+- `--port` when provided.
+- otherwise the `build.port` value from `sp-ui-plugin.json`.
+- otherwise the default dev server port (4200).
+
+## Developer URL
+
+On success the command prints a single fully qualified developer URL to stdout, for example `https://<tenant>/ui/plugin/<plugin-instance-id>?spPluginDev=<alias>`. Open it in a browser: `sp-renderer` verifies the override with UMS and, if you are authorized, loads your local code in the live tenant with a local-dev badge. The plugin URL is stable across links — re-running `link` with a different port updates the bound port without changing the URL.
+
+The URL is the only thing written to stdout (informational messages go to stderr) so it can be piped or picked up by your terminal's link detection without truncation or masking.
+
+## Output
+
+The developer URL is printed to stdout; a short confirmation of the linked port is printed to stderr. Backend failures are surfaced with actionable detail.
+====
+
+==Example==
+
+```bash
+# Link using the port from sp-ui-plugin.json's build.port (or the 4200 default)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins link
+
+# Link an explicit port, overriding build.port
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins link --port 4300
+```
+
+====

--- a/cmd/ui_plugins/link_test.go
+++ b/cmd/ui_plugins/link_test.go
@@ -1,0 +1,276 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/config"
+)
+
+const linkResolvedBody = `{"pluginInstanceId":"pi-123","alias":"access-request-plugin"}`
+
+func intPtr(i int) *int { return &i }
+
+// withTenantURL points config at a throwaway active environment with the given
+// tenant URL for the duration of the test, restoring the previous active
+// environment afterward. An empty url exercises the unconfigured-tenant path.
+func withTenantURL(t *testing.T, url string) {
+	t.Helper()
+	prev := config.GetActiveEnvironment()
+	config.SetActiveEnvironment("clitest")
+	config.SetTenantUrl(url)
+	t.Cleanup(func() {
+		config.SetTenantUrl("")
+		config.SetActiveEnvironment(prev)
+	})
+}
+
+func TestResolveLinkPort(t *testing.T) {
+	tests := []struct {
+		name          string
+		flagPort      int
+		portSet       bool
+		cfg           *uiPluginWorkspaceConfig
+		wantPort      int
+		wantDefaulted bool
+		wantErr       bool
+	}{
+		{
+			name:     "flag port takes precedence over build.port",
+			flagPort: 4300,
+			portSet:  true,
+			cfg:      &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{Port: intPtr(8080)}},
+			wantPort: 4300,
+		},
+		{
+			name:     "invalid flag port errors",
+			flagPort: 0,
+			portSet:  true,
+			cfg:      &uiPluginWorkspaceConfig{},
+			wantErr:  true,
+		},
+		{
+			name:          "nil build defaults",
+			portSet:       false,
+			cfg:           &uiPluginWorkspaceConfig{},
+			wantPort:      defaultDevServerPort,
+			wantDefaulted: true,
+		},
+		{
+			name:          "nil build.port defaults",
+			portSet:       false,
+			cfg:           &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{OutDir: "dist"}},
+			wantPort:      defaultDevServerPort,
+			wantDefaulted: true,
+		},
+		{
+			name:     "build.port used when set",
+			portSet:  false,
+			cfg:      &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{Port: intPtr(8080)}},
+			wantPort: 8080,
+		},
+		{
+			name:    "invalid build.port errors",
+			portSet: false,
+			cfg:     &uiPluginWorkspaceConfig{Build: &uiPluginBuildConfig{Port: intPtr(0)}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, defaulted, err := resolveLinkPort(tt.flagPort, tt.portSet, tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got port=%d defaulted=%v", port, defaulted)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if port != tt.wantPort {
+				t.Fatalf("port = %d, want %d", port, tt.wantPort)
+			}
+			if defaulted != tt.wantDefaulted {
+				t.Fatalf("defaulted = %v, want %v", defaulted, tt.wantDefaulted)
+			}
+		})
+	}
+}
+
+func TestLink_SuccessWithFlagPort(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   linkResolvedBody,
+		status:    http.StatusOK,
+		body:      `{}`,
+	}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, tempManifestPath(t, testManifestJSON), 4300, true, &out, &errOut)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fc.getCalls != 1 {
+		t.Fatalf("expected exactly one Get (resolve-alias), got %d", fc.getCalls)
+	}
+	if fc.postCalls != 1 {
+		t.Fatalf("expected exactly one Post (link), got %d", fc.postCalls)
+	}
+	wantURL := pluginInstancesEndpoint + "/pi-123/link"
+	if fc.gotURL != wantURL {
+		t.Fatalf("POST url = %s, want %s", fc.gotURL, wantURL)
+	}
+	if fc.gotPostHeaders[experimentalHeader] != "true" {
+		t.Fatalf("expected %s header on link POST, got: %v", experimentalHeader, fc.gotPostHeaders)
+	}
+	if got := strings.TrimSpace(string(fc.gotBody)); got != `{"port":4300}` {
+		t.Fatalf("link request body = %s, want {\"port\":4300}", got)
+	}
+
+	// stdout must carry only the developer URL so terminal link detection and
+	// piping work without truncation.
+	wantDevURL := "https://tenant.example.com/ui/plugin/pi-123?spPluginDev=access-request-plugin"
+	if got := strings.TrimSpace(out.String()); got != wantDevURL {
+		t.Fatalf("stdout = %q, want exactly %q", got, wantDevURL)
+	}
+	if strings.Contains(out.String(), "linked to port") {
+		t.Fatalf("stdout must not contain human diagnostics, got: %s", out.String())
+	}
+	if !strings.Contains(errOut.String(), "linked to port 4300") {
+		t.Fatalf("errOut should contain the human confirmation, got: %s", errOut.String())
+	}
+	if strings.Contains(errOut.String(), "defaulting to port") {
+		t.Fatalf("did not expect a defaulting notice when --port is set, got: %s", errOut.String())
+	}
+}
+
+func TestLink_UsesBuildPort(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	fc := &fakeClient{getStatus: http.StatusOK, getBody: linkResolvedBody, status: http.StatusOK, body: `{}`}
+	var out, errOut bytes.Buffer
+
+	// manifestWithBuildJSON declares build.port = 8080 and --port is not set.
+	err := link(context.Background(), fc, tempManifestPath(t, manifestWithBuildJSON), 0, false, &out, &errOut)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(string(fc.gotBody)); got != `{"port":8080}` {
+		t.Fatalf("link request body = %s, want {\"port\":8080}", got)
+	}
+	if strings.Contains(errOut.String(), "defaulting to port") {
+		t.Fatalf("did not expect a defaulting notice when build.port is set, got: %s", errOut.String())
+	}
+}
+
+func TestLink_DefaultsPortWhenUnset(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	fc := &fakeClient{getStatus: http.StatusOK, getBody: linkResolvedBody, status: http.StatusOK, body: `{}`}
+	var out, errOut bytes.Buffer
+
+	// testManifestJSON has no build section, so neither --port nor build.port is present.
+	err := link(context.Background(), fc, tempManifestPath(t, testManifestJSON), 0, false, &out, &errOut)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantBody := fmt.Sprintf(`{"port":%d}`, defaultDevServerPort)
+	if got := strings.TrimSpace(string(fc.gotBody)); got != wantBody {
+		t.Fatalf("link request body = %s, want %s", got, wantBody)
+	}
+	if !strings.Contains(errOut.String(), "defaulting to port") {
+		t.Fatalf("expected a defaulting notice on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestLink_EmptyTenantURLFailsFast(t *testing.T) {
+	withTenantURL(t, "")
+	fc := &fakeClient{}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, tempManifestPath(t, testManifestJSON), 0, false, &out, &errOut)
+	if err == nil || !strings.Contains(err.Error(), "no tenant URL configured") {
+		t.Fatalf("expected a tenant URL error, got: %v", err)
+	}
+	if fc.getCalls != 0 || fc.postCalls != 0 {
+		t.Fatalf("expected no client calls before the tenant URL check, got get=%d post=%d", fc.getCalls, fc.postCalls)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout, got: %s", out.String())
+	}
+}
+
+func TestLink_InvalidPortFailsBeforeClientCalls(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	fc := &fakeClient{}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, tempManifestPath(t, testManifestJSON), -1, true, &out, &errOut)
+	if err == nil || !strings.Contains(err.Error(), "provided port is invalid") {
+		t.Fatalf("expected an invalid port error, got: %v", err)
+	}
+	if fc.getCalls != 0 || fc.postCalls != 0 {
+		t.Fatalf("expected no client calls on an invalid port, got get=%d post=%d", fc.getCalls, fc.postCalls)
+	}
+}
+
+func TestLink_AliasResolutionFailureSkipsPost(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	fc := &fakeClient{getStatus: http.StatusNotFound, getBody: `{"message":"not found"}`}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, tempManifestPath(t, testManifestJSON), 4300, true, &out, &errOut)
+	if err == nil {
+		t.Fatal("expected an error when alias resolution fails")
+	}
+	if fc.postCalls != 0 {
+		t.Fatalf("expected no link POST after alias resolution failure, got %d", fc.postCalls)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout on failure, got: %s", out.String())
+	}
+}
+
+func TestLink_LinkErrorSurfaced(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   linkResolvedBody,
+		status:    http.StatusForbidden,
+		body:      `{"message":"Forbidden"}`,
+	}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, tempManifestPath(t, testManifestJSON), 4300, true, &out, &errOut)
+	if err == nil || !strings.Contains(err.Error(), "unable to create link") {
+		t.Fatalf("expected a link error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Forbidden") {
+		t.Fatalf("expected the backend message surfaced in the error, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout on link failure, got: %s", out.String())
+	}
+}
+
+func TestLink_TransportError(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   linkResolvedBody,
+		postErr:   errors.New("connection refused"),
+	}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, tempManifestPath(t, testManifestJSON), 4300, true, &out, &errOut)
+	if err == nil || !strings.Contains(err.Error(), "failed to create link") {
+		t.Fatalf("expected a wrapped transport error, got: %v", err)
+	}
+}

--- a/cmd/ui_plugins/ui_plugins.go
+++ b/cmd/ui_plugins/ui_plugins.go
@@ -37,6 +37,7 @@ func NewUIPluginsCommand() *cobra.Command {
 		newInitCommand(),
 		newCreateCommand(),
 		newLinkCommand(),
+		newUnlinkCommand(),
 		newUpdateCommand(),
 		newUploadCommand(),
 		newListCommand(),

--- a/cmd/ui_plugins/ui_plugins_test.go
+++ b/cmd/ui_plugins/ui_plugins_test.go
@@ -16,8 +16,8 @@ func TestNewUIPluginsCommandStructure(t *testing.T) {
 		t.Fatal("expected ui-plugins command to be hidden")
 	}
 
-	if len(cmd.Commands()) != 8 {
-		t.Fatalf("expected 8 subcommands, got %d", len(cmd.Commands()))
+	if len(cmd.Commands()) != 9 {
+		t.Fatalf("expected 9 subcommands, got %d", len(cmd.Commands()))
 	}
 }
 

--- a/cmd/ui_plugins/ui_plugins_test.go
+++ b/cmd/ui_plugins/ui_plugins_test.go
@@ -50,11 +50,11 @@ func TestUIPluginsGateEnabled(t *testing.T) {
 func TestUIPluginsStubReachableWhenEnabled(t *testing.T) {
 	t.Setenv(experimentalUIPluginsEnvVar, "1")
 	cmd := NewUIPluginsCommand()
-	cmd.SetArgs([]string{"link"})
+	cmd.SetArgs([]string{"update"})
 
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected link stub command to return not implemented error")
+		t.Fatal("expected update stub command to return not implemented error")
 	}
 
 	if !strings.Contains(err.Error(), "not implemented yet") {

--- a/cmd/ui_plugins/unlink.go
+++ b/cmd/ui_plugins/unlink.go
@@ -1,0 +1,84 @@
+package ui_plugins
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+//go:embed unlink.md
+var unlinkHelp string
+
+func newUnlinkCommand() *cobra.Command {
+	help := util.ParseHelp(unlinkHelp)
+	cmd := &cobra.Command{
+		Use:     "unlink",
+		Short:   "Remove your local development link for a UI plugin",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spClient, err := newPluginClient()
+			if err != nil {
+				return err
+			}
+			return runUnlink(context.Background(), spClient, manifestFileName, cmd.OutOrStdout())
+		},
+	}
+
+	return cmd
+}
+
+// runUnlink removes the authenticated developer's local dev server override from
+// the plugin instance resolved from the workspace alias. The removal is
+// idempotent: UMS returns success whether or not a mapping existed, so this
+// prints a confirmation in both cases. The client and output writer are injected
+// so the flow is testable without a live tenant.
+func runUnlink(ctx context.Context, c client.Client, manifestPath string, out io.Writer) error {
+	cfg, err := loadAndValidateWorkspaceManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	instance, _, err := resolvePluginInstanceByAlias(ctx, c, cfg.Manifest.Alias)
+	if err != nil {
+		return err
+	}
+
+	url := pluginInstancesEndpoint + "/" + neturl.PathEscape(instance.PluginInstanceID) + "/link"
+	resp, err := c.Delete(ctx, url, nil, uiPluginRequestHeaders())
+	if err != nil {
+		return fmt.Errorf("failed to remove link: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// The response body is read only to explain a failure.
+		respBody, _ := io.ReadAll(resp.Body)
+		return mapUMSUnlinkError(resp.StatusCode, respBody, cfg.Manifest.Alias)
+	}
+
+	fmt.Fprintf(out, "Removed the local dev link for plugin %q\n", instance.Alias)
+
+	return nil
+}
+
+// mapUMSUnlinkError translates a non-2xx unlink response into an actionable error.
+func mapUMSUnlinkError(status int, body []byte, alias string) error {
+	message := umsErrorMessage(body)
+	switch status {
+	case http.StatusForbidden:
+		return fmt.Errorf("not authorized to unlink UI plugins (requires the idn:plugins-ui:update right): %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("plugin instance for alias %q not found (or the UI plugins feature is not enabled for this tenant): %s", alias, message)
+	default:
+		return fmt.Errorf("failed to remove link for plugin %q (status %d): %s", alias, status, message)
+	}
+}

--- a/cmd/ui_plugins/unlink.md
+++ b/cmd/ui_plugins/unlink.md
@@ -1,0 +1,24 @@
+==Long==
+# Unlink
+
+Removes your local development link for a UI plugin so ISC stops loading your local code and returns to serving the deployed plugin. Run this from within an initialized plugin workspace; the alias is read from `./sp-ui-plugin.json`, and the active tenant is resolved from your CLI authentication.
+
+Unlinking affects only your own local dev override on the plugin instance — it never changes the deployed plugin or other developers' overrides. It is the inverse of `link`.
+
+## Idempotent
+
+Unlinking is safe to run whether or not a link currently exists. If you have no active local dev override for this plugin, the command reports success without making a change.
+
+## Output
+
+On success a short confirmation is printed. Backend failures are surfaced with actionable detail.
+====
+
+==Example==
+
+```bash
+# Remove your local dev link for the plugin in this workspace
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins unlink
+```
+
+====

--- a/cmd/ui_plugins/unlink_test.go
+++ b/cmd/ui_plugins/unlink_test.go
@@ -1,0 +1,139 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestRunUnlink_Success(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: linkResolvedBody}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out bytes.Buffer
+
+	err := runUnlink(context.Background(), c, tempManifestPath(t, testManifestJSON), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.deleteCalls != 1 {
+		t.Fatalf("expected exactly one Delete, got %d", c.deleteCalls)
+	}
+	wantURL := pluginInstancesEndpoint + "/pi-123/link"
+	if c.deleteURL != wantURL {
+		t.Fatalf("DELETE url = %s, want %s", c.deleteURL, wantURL)
+	}
+	if c.deleteHeaders[experimentalHeader] != "true" {
+		t.Fatalf("expected %s header on unlink DELETE, got: %v", experimentalHeader, c.deleteHeaders)
+	}
+	if got := out.String(); !strings.Contains(got, "Removed the local dev link") || !strings.Contains(got, "access-request-plugin") {
+		t.Fatalf("expected confirmation with alias, got: %s", got)
+	}
+}
+
+// A 204 is returned whether or not a mapping existed (UMS treats unlink as
+// idempotent), so the no-op case is indistinguishable from a real removal and
+// must still report success.
+func TestRunUnlink_NoOpStillConfirms(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: linkResolvedBody}},
+		deleteResp: stubResp{status: 204},
+	}
+	var out bytes.Buffer
+
+	err := runUnlink(context.Background(), c, tempManifestPath(t, testManifestJSON), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Removed the local dev link") {
+		t.Fatalf("expected a success confirmation for a no-op unlink, got: %s", out.String())
+	}
+}
+
+func TestRunUnlink_InvalidManifestSkipsClient(t *testing.T) {
+	c := &seqClient{}
+
+	err := runUnlink(context.Background(), c, tempManifestPath(t, `{"version":1}`), io.Discard)
+	if err == nil {
+		t.Fatal("expected an error for an invalid manifest")
+	}
+	if len(c.getURLs) != 0 || c.deleteCalls != 0 {
+		t.Fatalf("expected no client calls, got get=%d delete=%d", len(c.getURLs), c.deleteCalls)
+	}
+}
+
+func TestRunUnlink_AliasResolutionFailureSkipsDelete(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 404, body: `{"message":"not found"}`}}}
+
+	err := runUnlink(context.Background(), c, tempManifestPath(t, testManifestJSON), io.Discard)
+	if err == nil {
+		t.Fatal("expected an error when alias resolution fails")
+	}
+	if c.deleteCalls != 0 {
+		t.Fatalf("expected no Delete after alias resolution failure, got %d", c.deleteCalls)
+	}
+}
+
+func TestRunUnlink_ForbiddenMapped(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: linkResolvedBody}},
+		deleteResp: stubResp{status: 403, body: `{"message":"Forbidden"}`},
+	}
+	var out bytes.Buffer
+
+	err := runUnlink(context.Background(), c, tempManifestPath(t, testManifestJSON), &out)
+	if err == nil || !strings.Contains(err.Error(), "not authorized to unlink") {
+		t.Fatalf("expected forbidden mapping, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no confirmation on error, got: %s", out.String())
+	}
+}
+
+func TestRunUnlink_NotFoundMapped(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: linkResolvedBody}},
+		deleteResp: stubResp{status: 404, body: `{"message":"Not Found"}`},
+	}
+
+	err := runUnlink(context.Background(), c, tempManifestPath(t, testManifestJSON), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found mapping, got: %v", err)
+	}
+}
+
+func TestRunUnlink_TransportError(t *testing.T) {
+	c := &seqClient{
+		getQueue:   []stubResp{{status: 200, body: linkResolvedBody}},
+		deleteResp: stubResp{err: errors.New("connection refused")},
+	}
+
+	err := runUnlink(context.Background(), c, tempManifestPath(t, testManifestJSON), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "failed to remove link") {
+		t.Fatalf("expected wrapped transport error, got: %v", err)
+	}
+}
+
+func TestMapUMSUnlinkError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"forbidden", 403, "not authorized to unlink"},
+		{"not found", 404, "not found"},
+		{"unexpected", 500, "status 500"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mapUMSUnlinkError(tt.status, []byte(`{"message":"boom"}`), "my-plugin")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q, got: %v", tt.want, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR adds both `link` and `unlink` commands to the ui-plugins command group. Additionally it switches the default port to 4200

## How Has This Been Tested?
Unit tests have been added and Manual Testing as described in the MV ticket CSTM-330