### PR TITLE
CSTM-343: Adding enable and disable commands to ui-plugins command group

### DIFF
--- a/cmd/ui_plugins/delete.go
+++ b/cmd/ui_plugins/delete.go
@@ -48,7 +48,7 @@ func newDeleteCommand() *cobra.Command {
 // ambiguous-alias and not-found guards are always enforced. When jsonOutput is set,
 // the confirmation is written to errOut so stdout carries only the resulting JSON.
 func runDelete(ctx context.Context, c client.Client, in io.Reader, out io.Writer, errOut io.Writer, arg string, force bool, jsonOutput bool) error {
-	inst, raw, err := resolveDeleteTarget(ctx, c, arg)
+	inst, raw, err := resolvePluginTarget(ctx, c, arg)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func runDelete(ctx context.Context, c client.Client, in io.Reader, out io.Writer
 		if jsonOutput {
 			promptOut = errOut
 		}
-		renderDeleteConfirmation(promptOut, inst)
+		renderConfirmation(promptOut, "delete", inst)
 
 		confirmed, err := promptYesNo(in, promptOut, fmt.Sprintf("Delete plugin instance %s?", inst.PluginInstanceID))
 		if err != nil {

--- a/cmd/ui_plugins/disable.go
+++ b/cmd/ui_plugins/disable.go
@@ -1,0 +1,98 @@
+package ui_plugins
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+
+	"strings"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+//go:embed disable.md
+var disableHelp string
+
+func newDisableCommand() *cobra.Command {
+	var force bool
+	var jsonOutput bool
+
+	help := util.ParseHelp(disableHelp)
+	cmd := &cobra.Command{
+		Use:     "disable (alias | plugin-id)",
+		Short:   "Disable a UI plugin instance",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spClient, err := newPluginClient()
+			if err != nil {
+				return err
+			}
+			return runDisable(context.Background(), spClient, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], force, jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "F", false, "Bypass confirmation prompts")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the disabled plugin instance as JSON")
+
+	return cmd
+}
+
+// runDisable resolves the target (by alias or plugin ID), confirms disabling
+// (unless force), then disables it. The confirmation is skipped by force, but the
+// ambiguous-alias and not-found guards are always enforced. When jsonOutput is set,
+// the confirmation is written to errOut so stdout carries only the resulting JSON.
+func runDisable(ctx context.Context, c client.Client, in io.Reader, out io.Writer, errOut io.Writer, arg string, force bool, jsonOutput bool) error {
+	inst, raw, err := resolvePluginTarget(ctx, c, arg)
+	if err != nil {
+		return err
+	}
+
+	if inst.State == stateDisabled {
+		writer := out
+		if jsonOutput {
+			writer = errOut
+		}
+
+		_, _ = fmt.Fprintf(writer, "Plugin instance %s is already disabled\n", pluginInstanceLabel(inst))
+
+		if jsonOutput {
+			_, _ = fmt.Fprintln(out, strings.TrimSpace(string(raw)))
+		}
+		return nil
+	}
+
+	if !force {
+		promptOut := out
+		if jsonOutput {
+			promptOut = errOut
+		}
+		renderConfirmation(promptOut, "disable", inst)
+
+		confirmed, err := promptYesNo(in, promptOut, fmt.Sprintf("Disable plugin instance %s?", inst.PluginInstanceID))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			_, _ = fmt.Fprintln(promptOut, "Cancelled.")
+			return nil
+		}
+	}
+
+	response, err := setPluginInstanceState(ctx, c, inst, stateDisabled)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		_, _ = fmt.Fprintln(out, strings.TrimSpace(string(response)))
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "Disabled plugin instance %s\n", pluginInstanceLabel(inst))
+
+	return nil
+}

--- a/cmd/ui_plugins/disable.md
+++ b/cmd/ui_plugins/disable.md
@@ -1,0 +1,45 @@
+==Long==
+# Disable
+
+Disables a UI plugin instance from the current tenant, identified by either its alias or its plugin ID.
+
+Before disabling, the command looks up the instance and prints a summary (alias, name, plugin ID, created date, and slots) for you to confirm. If the instance has an active asset bundle (a live deployment), a warning is shown.
+
+## Identifying the instance
+
+The single argument accepts either an alias or a plugin ID; the type is detected automatically by its shape:
+
+- A value in UUID form is treated as a plugin ID.
+- Anything else is treated as an alias and resolved to its plugin ID first.
+
+A UUID is technically also a valid alias. If you register an alias that looks like a UUID, this command will treat that argument as a plugin ID and report "not found" — it will never disable a different instance. Such an instance can still be disabled by passing its plugin ID.
+
+## Confirmation and --force
+
+Disabling requires confirmation (the prompt defaults to No). `--force` (`-F`) skips the confirmation prompt only — it does not bypass safety checks:
+
+- If an alias resolves to more than one instance, the command lists the conflicting plugin IDs and stops, even with `--force`. Re-run with a specific plugin ID.
+- A missing instance is always reported as an error.
+
+## Output
+
+On success a confirmation with the disabled plugin ID (and alias, when known) is printed. Use `--json` to print the disabled plugin instance as JSON instead.
+====
+
+==Example==
+
+```bash
+# Disable by alias (prompts for confirmation)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins disable access-request-plugin
+
+# Disable by plugin ID
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins disable 2c918085-7a1e-1b2c-817a-1e1b2c000000
+
+# Skip the confirmation prompt
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins disable access-request-plugin --force
+
+# Print the disabled instance as JSON (scripting)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins disable access-request-plugin --force --json
+```
+
+====

--- a/cmd/ui_plugins/disable_test.go
+++ b/cmd/ui_plugins/disable_test.go
@@ -1,0 +1,245 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// enabledInstanceBody is a resolved instance in the ENABLED state, so a disable
+// proceeds to the PATCH rather than short-circuiting on idempotency.
+const enabledInstanceBody = `{"pluginInstanceId":"pi-1","alias":"my-plugin","name":{"en":"My Plugin"},"created":"2026-05-01T00:00:00Z","state":"ENABLED","slots":[{"slotId":"full-page"}]}`
+
+// disabledPatchResponse is the instance as returned by the PATCH, now DISABLED.
+// The `modified` field is unique to the PATCH response so tests can prove that
+// --json emits the post-change document rather than the pre-change resolve body.
+const disabledPatchResponse = `{"pluginInstanceId":"pi-1","alias":"my-plugin","state":"DISABLED","modified":"2026-07-29T00:00:00Z"}`
+
+func TestRunDisable_ConfirmYesDisables(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: enabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: disabledPatchResponse},
+	}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 1 {
+		t.Fatalf("expected 1 Patch, got %d", c.patchCalls)
+	}
+	if !strings.HasSuffix(c.patchURL, "/pi-1") {
+		t.Fatalf("expected PATCH on resolved id, got: %s", c.patchURL)
+	}
+	if got := strings.TrimSpace(string(c.patchBody)); got != `{"state":"DISABLED"}` {
+		t.Fatalf("unexpected PATCH body: %s", got)
+	}
+	if got := c.patchHeaders["Content-Type"]; got != "application/json" {
+		t.Fatalf("PATCH must set Content-Type application/json, got: %q", got)
+	}
+	got := out.String()
+	if !strings.Contains(got, "full-page") {
+		t.Fatalf("expected confirmation to show slots, got: %s", got)
+	}
+	if !strings.Contains(got, "Disabled plugin instance pi-1 (alias: my-plugin)") {
+		t.Fatalf("expected success message with id and alias, got: %s", got)
+	}
+}
+
+func TestRunDisable_DeclineDoesNotDisable(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: enabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: disabledPatchResponse},
+	}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader("n\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("declining must not call Patch")
+	}
+	if !strings.Contains(out.String(), "Cancelled.") {
+		t.Fatalf("expected cancellation message, got: %s", out.String())
+	}
+}
+
+func TestRunDisable_EmptyInputDefaultsToNo(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: enabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: disabledPatchResponse},
+	}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader("\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("empty input must default to No and not disable")
+	}
+}
+
+func TestRunDisable_ForceSkipsPrompt(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: enabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: disabledPatchResponse},
+	}
+	var out bytes.Buffer
+
+	// Empty stdin: if the prompt were shown, it would default to No and skip the PATCH.
+	err := runDisable(context.Background(), c, strings.NewReader(""), &out, &out, "my-plugin", true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 1 {
+		t.Fatalf("--force should disable without prompting, got %d Patch calls", c.patchCalls)
+	}
+	if strings.Contains(out.String(), "[y/N]") {
+		t.Fatalf("--force should not print a prompt, got: %s", out.String())
+	}
+}
+
+func TestRunDisable_AlreadyDisabledSkipsPatch(t *testing.T) {
+	body := `{"pluginInstanceId":"pi-1","alias":"my-plugin","state":"DISABLED"}`
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: body}}}
+	var out, errOut bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader(""), &out, &errOut, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("an already-disabled instance must not PATCH")
+	}
+	if !strings.Contains(out.String(), "already disabled") || !strings.Contains(out.String(), "pi-1") {
+		t.Fatalf("expected already-disabled notice on stdout, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "[y/N]") {
+		t.Fatalf("idempotent path must not prompt, got: %s", out.String())
+	}
+}
+
+func TestRunDisable_AlreadyDisabledJSON(t *testing.T) {
+	body := `{"pluginInstanceId":"pi-1","alias":"my-plugin","state":"DISABLED"}`
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: body}}}
+	var out, errOut bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader(""), &out, &errOut, "my-plugin", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("an already-disabled instance must not PATCH")
+	}
+	if !strings.Contains(out.String(), `"pluginInstanceId":"pi-1"`) {
+		t.Fatalf("--json stdout should carry the instance JSON, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "already disabled") {
+		t.Fatalf("--json stdout must be pure JSON, got: %s", out.String())
+	}
+	if !strings.Contains(errOut.String(), "already disabled") {
+		t.Fatalf("expected already-disabled notice on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestRunDisable_JSONEmitsUpdatedInstance(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: enabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: disabledPatchResponse},
+	}
+	var out, errOut bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader(""), &out, &errOut, "my-plugin", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// stdout must carry the PATCH response (post-change), not the stale resolve body:
+	// `modified` and DISABLED both appear only in the PATCH response.
+	if !strings.Contains(out.String(), `"modified"`) || !strings.Contains(out.String(), `"state":"DISABLED"`) {
+		t.Fatalf("expected updated instance JSON on stdout, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "Disabled plugin instance") {
+		t.Fatalf("--json stdout should be pure JSON, got: %s", out.String())
+	}
+}
+
+func TestRunDisable_NotFoundBeforePrompt(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 404, body: `{"message":"Not Found"}`}}}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader("y\n"), &out, &out, "missing", false, false)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("must not PATCH when target not found")
+	}
+	if strings.Contains(out.String(), "[y/N]") {
+		t.Fatalf("must not prompt when target resolution fails, got: %s", out.String())
+	}
+}
+
+func TestRunDisable_AmbiguousNotDisabledEvenWithForce(t *testing.T) {
+	body := `{"conflicts":[{"pluginInstanceId":"pi-1"},{"pluginInstanceId":"pi-2"}]}`
+	c := &seqClient{getQueue: []stubResp{{status: 409, body: body}}}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader(""), &out, &out, "dup-plugin", true, false)
+	if err == nil {
+		t.Fatal("expected ambiguity error even with --force")
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("ambiguous alias must never be disabled, even with --force")
+	}
+	if !strings.Contains(err.Error(), "pi-1") || !strings.Contains(err.Error(), "pi-2") {
+		t.Fatalf("expected conflicting IDs in error, got: %v", err)
+	}
+}
+
+func TestRunDisable_ActiveBundleWarning(t *testing.T) {
+	body := `{"pluginInstanceId":"pi-1","alias":"my-plugin","state":"ENABLED","activeAssetBundleId":"ab-9","slots":[{"slotId":"full-page"}]}`
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: body}},
+		patchResp: stubResp{status: 200, body: disabledPatchResponse},
+	}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "active asset bundle") {
+		t.Fatalf("expected active-deployment warning, got: %s", out.String())
+	}
+}
+
+func TestRunDisable_UpdateErrorMapping(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: enabledInstanceBody}},
+		patchResp: stubResp{status: 403, body: `{"message":"Forbidden"}`},
+	}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err == nil || !strings.Contains(err.Error(), "not authorized to update") {
+		t.Fatalf("expected update forbidden mapping, got: %v", err)
+	}
+}
+
+func TestRunDisable_TransportError(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: enabledInstanceBody}},
+		patchResp: stubResp{err: errors.New("connection refused")},
+	}
+	var out bytes.Buffer
+
+	err := runDisable(context.Background(), c, strings.NewReader("y\n"), &out, &out, "my-plugin", false, false)
+	if err == nil || !strings.Contains(err.Error(), "failed to update plugin instance state") {
+		t.Fatalf("expected wrapped transport error, got: %v", err)
+	}
+}

--- a/cmd/ui_plugins/enable.go
+++ b/cmd/ui_plugins/enable.go
@@ -1,0 +1,77 @@
+package ui_plugins
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+
+	"strings"
+
+	"github.com/sailpoint-oss/sailpoint-cli/internal/client"
+	"github.com/sailpoint-oss/sailpoint-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+//go:embed enable.md
+var enableHelp string
+
+func newEnableCommand() *cobra.Command {
+	var jsonOutput bool
+
+	help := util.ParseHelp(enableHelp)
+	cmd := &cobra.Command{
+		Use:     "enable (alias | plugin-id)",
+		Short:   "Enable a UI plugin instance",
+		Long:    help.Long,
+		Example: help.Example,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spClient, err := newPluginClient()
+			if err != nil {
+				return err
+			}
+			return runEnable(context.Background(), spClient, cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the enabled plugin instance as JSON")
+
+	return cmd
+}
+
+// runEnable resolves the target (by alias or plugin ID), then enables
+// it.
+func runEnable(ctx context.Context, c client.Client, out io.Writer, errOut io.Writer, arg string, jsonOutput bool) error {
+	inst, raw, err := resolvePluginTarget(ctx, c, arg)
+	if err != nil {
+		return err
+	}
+
+	if inst.State == stateEnabled {
+		writer := out
+		if jsonOutput {
+			writer = errOut
+		}
+		_, _ = fmt.Fprintf(writer, "Plugin instance %s is already enabled\n", pluginInstanceLabel(inst))
+
+		if jsonOutput {
+			_, _ = fmt.Fprintln(out, strings.TrimSpace(string(raw)))
+		}
+		return nil
+	}
+
+	response, err := setPluginInstanceState(ctx, c, inst, stateEnabled)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		_, _ = fmt.Fprintln(out, strings.TrimSpace(string(response)))
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(out, "Enabled plugin instance %s\n", pluginInstanceLabel(inst))
+
+	return nil
+}

--- a/cmd/ui_plugins/enable.md
+++ b/cmd/ui_plugins/enable.md
@@ -1,0 +1,35 @@
+==Long==
+# Enable
+
+Enables a UI plugin instance from the current tenant, identified by either its alias or its plugin ID.
+
+## Identifying the instance
+
+The single argument accepts either an alias or a plugin ID; the type is detected automatically by its shape:
+
+- A value in UUID form is treated as a plugin ID.
+- Anything else is treated as an alias and resolved to its plugin ID first.
+- If an alias resolves to more than one instance, the command lists the conflicting plugin IDs and stops. Re-run with a specific plugin ID.
+- A missing instance is always reported as an error.
+
+A UUID is technically also a valid alias. If you register an alias that looks like a UUID, this command will treat that argument as a plugin ID and report "not found" — it will never enable a different instance. Such an instance can still be enabled by passing its plugin ID.
+
+## Output
+
+On success a confirmation with the enabled plugin ID (and alias, when known) is printed. Use `--json` to print the enabled plugin instance as JSON instead.
+====
+
+==Example==
+
+```bash
+# Enable by alias
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins enable access-request-plugin
+
+# Enable by plugin ID
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins enable 2c918085-7a1e-1b2c-817a-1e1b2c000000
+
+# Print the enabled instance as JSON (scripting)
+SAIL_EXPERIMENTAL_UI_PLUGINS=1 sail ui-plugins enable access-request-plugin --json
+```
+
+====

--- a/cmd/ui_plugins/enable_test.go
+++ b/cmd/ui_plugins/enable_test.go
@@ -1,0 +1,179 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// disabledInstanceBody is a resolved instance in the DISABLED state, so an enable
+// proceeds to the PATCH rather than short-circuiting on idempotency.
+const disabledInstanceBody = `{"pluginInstanceId":"pi-1","alias":"my-plugin","name":{"en":"My Plugin"},"created":"2026-05-01T00:00:00Z","state":"DISABLED"}`
+
+// enabledPatchResponse is the instance as returned by the PATCH, now ENABLED. The
+// `modified` field is unique to the PATCH response so tests can prove that --json
+// emits the post-change document rather than the pre-change resolve body.
+const enabledPatchResponse = `{"pluginInstanceId":"pi-1","alias":"my-plugin","state":"ENABLED","modified":"2026-07-29T00:00:00Z"}`
+
+func TestRunEnable_Enables(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: disabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: enabledPatchResponse},
+	}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "my-plugin", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 1 {
+		t.Fatalf("expected 1 Patch, got %d", c.patchCalls)
+	}
+	if !strings.HasSuffix(c.patchURL, "/pi-1") {
+		t.Fatalf("expected PATCH on resolved id, got: %s", c.patchURL)
+	}
+	if got := strings.TrimSpace(string(c.patchBody)); got != `{"state":"ENABLED"}` {
+		t.Fatalf("unexpected PATCH body: %s", got)
+	}
+	if got := c.patchHeaders["Content-Type"]; got != "application/json" {
+		t.Fatalf("PATCH must set Content-Type application/json, got: %q", got)
+	}
+	if !strings.Contains(out.String(), "Enabled plugin instance pi-1 (alias: my-plugin)") {
+		t.Fatalf("expected success message with id and alias, got: %s", out.String())
+	}
+}
+
+func TestRunEnable_NoConfirmationPrompt(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: disabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: enabledPatchResponse},
+	}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "my-plugin", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// enable is non-destructive and intentionally has no confirmation.
+	if strings.Contains(out.String(), "[y/N]") || strings.Contains(out.String(), "You are about to") {
+		t.Fatalf("enable must not prompt for confirmation, got: %s", out.String())
+	}
+}
+
+func TestRunEnable_AlreadyEnabledSkipsPatch(t *testing.T) {
+	body := `{"pluginInstanceId":"pi-1","alias":"my-plugin","state":"ENABLED"}`
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: body}}}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "my-plugin", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("an already-enabled instance must not PATCH")
+	}
+	if !strings.Contains(out.String(), "already enabled") || !strings.Contains(out.String(), "pi-1") {
+		t.Fatalf("expected already-enabled notice on stdout, got: %s", out.String())
+	}
+}
+
+func TestRunEnable_AlreadyEnabledJSON(t *testing.T) {
+	body := `{"pluginInstanceId":"pi-1","alias":"my-plugin","state":"ENABLED"}`
+	c := &seqClient{getQueue: []stubResp{{status: 200, body: body}}}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "my-plugin", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("an already-enabled instance must not PATCH")
+	}
+	if !strings.Contains(out.String(), `"pluginInstanceId":"pi-1"`) {
+		t.Fatalf("--json stdout should carry the instance JSON, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "already enabled") {
+		t.Fatalf("--json stdout must be pure JSON, got: %s", out.String())
+	}
+	if !strings.Contains(errOut.String(), "already enabled") {
+		t.Fatalf("expected already-enabled notice on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestRunEnable_JSONEmitsUpdatedInstance(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: disabledInstanceBody}},
+		patchResp: stubResp{status: 200, body: enabledPatchResponse},
+	}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "my-plugin", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// stdout must carry the PATCH response (post-change), not the stale resolve body.
+	if !strings.Contains(out.String(), `"modified"`) || !strings.Contains(out.String(), `"state":"ENABLED"`) {
+		t.Fatalf("expected updated instance JSON on stdout, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "Enabled plugin instance") {
+		t.Fatalf("--json stdout should be pure JSON, got: %s", out.String())
+	}
+}
+
+func TestRunEnable_NotFound(t *testing.T) {
+	c := &seqClient{getQueue: []stubResp{{status: 404, body: `{"message":"Not Found"}`}}}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "missing", false)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got: %v", err)
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("must not PATCH when target not found")
+	}
+}
+
+func TestRunEnable_AmbiguousAlias(t *testing.T) {
+	body := `{"conflicts":[{"pluginInstanceId":"pi-1"},{"pluginInstanceId":"pi-2"}]}`
+	c := &seqClient{getQueue: []stubResp{{status: 409, body: body}}}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "dup-plugin", false)
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	if c.patchCalls != 0 {
+		t.Fatal("ambiguous alias must never be enabled")
+	}
+	if !strings.Contains(err.Error(), "pi-1") || !strings.Contains(err.Error(), "pi-2") {
+		t.Fatalf("expected conflicting IDs in error, got: %v", err)
+	}
+}
+
+func TestRunEnable_UpdateErrorMapping(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: disabledInstanceBody}},
+		patchResp: stubResp{status: 403, body: `{"message":"Forbidden"}`},
+	}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "my-plugin", false)
+	if err == nil || !strings.Contains(err.Error(), "not authorized to update") {
+		t.Fatalf("expected update forbidden mapping, got: %v", err)
+	}
+}
+
+func TestRunEnable_TransportError(t *testing.T) {
+	c := &seqClient{
+		getQueue:  []stubResp{{status: 200, body: disabledInstanceBody}},
+		patchResp: stubResp{err: errors.New("connection refused")},
+	}
+	var out, errOut bytes.Buffer
+
+	err := runEnable(context.Background(), c, &out, &errOut, "my-plugin", false)
+	if err == nil || !strings.Contains(err.Error(), "failed to update plugin instance state") {
+		t.Fatalf("expected wrapped transport error, got: %v", err)
+	}
+}

--- a/cmd/ui_plugins/manifest_model.go
+++ b/cmd/ui_plugins/manifest_model.go
@@ -23,6 +23,7 @@ type uiPluginManifest struct {
 	ContentSecurityPolicies map[string][]string `json:"contentSecurityPolicies"`
 	PermissionPolicy        map[string][]string `json:"permissionPolicy"`
 	IframeAllow             map[string][]string `json:"iframeAllow"`
+	State                   *pluginState        `json:"state"`
 	Slots                   []uiPluginSlot      `json:"slots"`
 }
 
@@ -31,4 +32,3 @@ type uiPluginBuildConfig struct {
 	OutDir string `json:"outDir,omitempty"`
 	Port   *int   `json:"port,omitempty"`
 }
-

--- a/cmd/ui_plugins/manifest_validation.go
+++ b/cmd/ui_plugins/manifest_validation.go
@@ -48,6 +48,11 @@ func parseWorkspaceManifestStrict(raw []byte) (*uiPluginWorkspaceConfig, error) 
 		return nil, fmt.Errorf("manifest must contain a single JSON object")
 	}
 
+	if cfg.Manifest.State == nil {
+		defaultState := stateEnabled
+		cfg.Manifest.State = &defaultState
+	}
+
 	return &cfg, nil
 }
 
@@ -101,4 +106,3 @@ func validateWorkspaceManifest(cfg *uiPluginWorkspaceConfig) error {
 
 	return nil
 }
-

--- a/cmd/ui_plugins/manifest_validation_test.go
+++ b/cmd/ui_plugins/manifest_validation_test.go
@@ -354,4 +354,3 @@ func writeManifestFixture(t *testing.T, content string) string {
 	}
 	return path
 }
-

--- a/cmd/ui_plugins/plugin_instance.go
+++ b/cmd/ui_plugins/plugin_instance.go
@@ -2,6 +2,7 @@ package ui_plugins
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,6 +29,17 @@ const (
 	tableColumnMaxWidth = 40
 )
 
+type pluginState string
+
+const (
+	stateEnabled  pluginState = "ENABLED"
+	stateDisabled pluginState = "DISABLED"
+)
+
+type statePayload struct {
+	State string `json:"state"`
+}
+
 // pluginInstance is the subset of the UMS PluginInstanceDto the list and delete
 // commands need for display. Unrecognized fields are ignored on decode; the raw
 // body is preserved separately when --json fidelity is required.
@@ -37,6 +49,7 @@ type pluginInstance struct {
 	Name                map[string]string `json:"name"`
 	Created             string            `json:"created"`
 	Slots               []uiPluginSlot    `json:"slots"`
+	State               pluginState       `json:"state"`
 	ActiveAssetBundleID *string           `json:"activeAssetBundleId"`
 }
 
@@ -87,10 +100,10 @@ func listPluginInstances(ctx context.Context, c client.Client) ([]json.RawMessag
 	return all, nil
 }
 
-// resolveDeleteTarget resolves a delete argument to a plugin instance, choosing the
+// resolvePluginTarget resolves a plugin argument to a plugin instance, choosing the
 // lookup by the argument's shape: a UUID is looked up by ID, anything else by alias.
 // It returns the typed instance and its raw response body (for --json).
-func resolveDeleteTarget(ctx context.Context, c client.Client, arg string) (*pluginInstance, []byte, error) {
+func resolvePluginTarget(ctx context.Context, c client.Client, arg string) (*pluginInstance, []byte, error) {
 	if looksLikeUUID(arg) {
 		return getPluginInstanceByID(ctx, c, arg)
 	}
@@ -171,6 +184,36 @@ func ambiguousAliasError(alias string, body []byte) error {
 	return fmt.Errorf("alias %q resolves to multiple plugin instances; re-run delete with a specific plugin ID: %s", alias, umsErrorMessage(body))
 }
 
+// setPluginInstanceState updates a plugin instance state to the
+// provided value (desired).
+func setPluginInstanceState(ctx context.Context, c client.Client, instance *pluginInstance, desired pluginState) ([]byte, error) {
+
+	payload, err := json.Marshal(statePayload{State: string(desired)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update plugin instance state: %w", err)
+	}
+
+	headers := uiPluginRequestHeaders()
+	headers["Content-Type"] = "application/json"
+
+	url := pluginInstancesEndpoint + "/" + neturl.PathEscape(instance.PluginInstanceID)
+	resp, err := c.Patch(ctx, url, bytes.NewReader(payload), headers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update plugin instance state: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, mapUMSUpdateError(resp.StatusCode, body, instance.Alias)
+	}
+
+	return body, nil
+}
+
 // localizedName returns a display name from a localized name map, preferring the
 // English locale and falling back to the first locale in sorted order.
 func localizedName(name map[string]string) string {
@@ -203,9 +246,10 @@ func renderPluginInstanceTable(w io.Writer, items []pluginInstance) {
 			p.PluginInstanceID,
 			truncateForTable(localizedName(p.Name), tableColumnMaxWidth),
 			p.Created,
+			string(p.State),
 		})
 	}
-	output.WriteTable(w, []string{"Alias", "Id", "Name", "Created"}, rows, "Alias")
+	output.WriteTable(w, []string{"Alias", "Id", "Name", "Created", "State"}, rows, "Alias")
 }
 
 // truncateForTable shortens s to at most maxRunes runes, appending an ellipsis when
@@ -222,10 +266,10 @@ func truncateForTable(s string, maxRunes int) string {
 	return string(runes[:maxRunes-1]) + "…"
 }
 
-// renderDeleteConfirmation prints the details of the instance about to be deleted,
-// warning when it has an active asset bundle (a live deployment).
-func renderDeleteConfirmation(w io.Writer, inst *pluginInstance) {
-	fmt.Fprintln(w, "You are about to delete the following UI plugin instance:")
+// renderConfirmation prints the details of the instance, warning when
+// it has an active asset bundle (a live deployment).
+func renderConfirmation(w io.Writer, action string, inst *pluginInstance) {
+	fmt.Fprintf(w, "You are about to %s the following UI plugin instance:\n", action)
 	fmt.Fprintf(w, "  Alias:     %s\n", inst.Alias)
 	fmt.Fprintf(w, "  Name:      %s\n", localizedName(inst.Name))
 	fmt.Fprintf(w, "  Plugin ID: %s\n", inst.PluginInstanceID)
@@ -299,4 +343,14 @@ func mapUMSDeleteError(status int, body []byte, target string) error {
 	default:
 		return fmt.Errorf("failed to delete plugin instance %q (status %d): %s", target, status, message)
 	}
+}
+
+// pluginInstanceLabel returns a formatted string with alias if the
+// provided plugin instance has an alias, otherwise it returns the
+// plugin instance id.
+func pluginInstanceLabel(inst *pluginInstance) string {
+	if inst.Alias != "" {
+		return fmt.Sprintf("%s (alias: %s)", inst.PluginInstanceID, inst.Alias)
+	}
+	return inst.PluginInstanceID
 }

--- a/cmd/ui_plugins/plugin_instance_test.go
+++ b/cmd/ui_plugins/plugin_instance_test.go
@@ -221,7 +221,7 @@ func TestResolveDeleteTarget_UUIDUsesGetByID(t *testing.T) {
 	id := "2c918085-7a1e-1b2c-817a-1e1b2c000000"
 	c := &seqClient{getQueue: []stubResp{{status: 200, body: `{"pluginInstanceId":"` + id + `","alias":"my-plugin"}`}}}
 
-	inst, _, err := resolveDeleteTarget(context.Background(), c, id)
+	inst, _, err := resolvePluginTarget(context.Background(), c, id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestResolveDeleteTarget_UUIDUsesGetByID(t *testing.T) {
 func TestResolveDeleteTarget_AliasUsesResolve(t *testing.T) {
 	c := &seqClient{getQueue: []stubResp{{status: 200, body: `{"pluginInstanceId":"pi-1","alias":"my-plugin"}`}}}
 
-	inst, _, err := resolveDeleteTarget(context.Background(), c, "my-plugin")
+	inst, _, err := resolvePluginTarget(context.Background(), c, "my-plugin")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestResolveDeleteTarget_AliasUsesResolve(t *testing.T) {
 
 func TestResolveDeleteTarget_NotFound(t *testing.T) {
 	c := &seqClient{getQueue: []stubResp{{status: 404, body: `{"message":"Not Found"}`}}}
-	_, _, err := resolveDeleteTarget(context.Background(), c, "missing-plugin")
+	_, _, err := resolvePluginTarget(context.Background(), c, "missing-plugin")
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("expected not-found error, got: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestResolveDeleteTarget_AmbiguousAlias(t *testing.T) {
 	body := `{"message":"Alias resolves to multiple plugin instances","conflicts":[{"pluginInstanceId":"pi-1"},{"pluginInstanceId":"pi-2"}]}`
 	c := &seqClient{getQueue: []stubResp{{status: 409, body: body}}}
 
-	_, _, err := resolveDeleteTarget(context.Background(), c, "dup-plugin")
+	_, _, err := resolvePluginTarget(context.Background(), c, "dup-plugin")
 	if err == nil {
 		t.Fatal("expected ambiguity error")
 	}
@@ -269,5 +269,79 @@ func TestResolveDeleteTarget_AmbiguousAlias(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "specific plugin ID") {
 		t.Fatalf("expected guidance to use a plugin ID, got: %v", err)
+	}
+}
+
+func TestPluginInstanceLabel(t *testing.T) {
+	withAlias := &pluginInstance{PluginInstanceID: "pi-1", Alias: "my-plugin"}
+	if got := pluginInstanceLabel(withAlias); got != "pi-1 (alias: my-plugin)" {
+		t.Fatalf("with alias: got %q", got)
+	}
+
+	noAlias := &pluginInstance{PluginInstanceID: "pi-1"}
+	if got := pluginInstanceLabel(noAlias); got != "pi-1" {
+		t.Fatalf("without alias: got %q", got)
+	}
+}
+
+func TestSetPluginInstanceState_DisableSuccess(t *testing.T) {
+	c := &seqClient{patchResp: stubResp{status: 200, body: `{"pluginInstanceId":"pi-1","state":"DISABLED"}`}}
+	inst := &pluginInstance{PluginInstanceID: "pi-1", Alias: "my-plugin"}
+
+	body, err := setPluginInstanceState(context.Background(), c, inst, stateDisabled)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.patchCalls != 1 {
+		t.Fatalf("expected 1 Patch, got %d", c.patchCalls)
+	}
+	if !strings.HasSuffix(c.patchURL, "/pi-1") {
+		t.Fatalf("expected PATCH on the instance id, got: %s", c.patchURL)
+	}
+	// The Content-Type header is required: without it UMS silently ignores the
+	// body, bumps `modified`, and leaves state unchanged. Guard against regressing it.
+	if got := c.patchHeaders["Content-Type"]; got != "application/json" {
+		t.Fatalf("PATCH must set Content-Type application/json, got %q (headers: %v)", got, c.patchHeaders)
+	}
+	if got := c.patchHeaders[experimentalHeader]; got != "true" {
+		t.Fatalf("PATCH missing %s header, got: %v", experimentalHeader, c.patchHeaders)
+	}
+	if got := strings.TrimSpace(string(c.patchBody)); got != `{"state":"DISABLED"}` {
+		t.Fatalf("unexpected PATCH body: %s", got)
+	}
+	if !strings.Contains(string(body), `"state":"DISABLED"`) {
+		t.Fatalf("expected the PATCH response body returned, got: %s", body)
+	}
+}
+
+func TestSetPluginInstanceState_EnableBody(t *testing.T) {
+	c := &seqClient{patchResp: stubResp{status: 200, body: `{}`}}
+	inst := &pluginInstance{PluginInstanceID: "pi-1"}
+
+	if _, err := setPluginInstanceState(context.Background(), c, inst, stateEnabled); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(string(c.patchBody)); got != `{"state":"ENABLED"}` {
+		t.Fatalf("unexpected PATCH body: %s", got)
+	}
+}
+
+func TestSetPluginInstanceState_ErrorMapping(t *testing.T) {
+	c := &seqClient{patchResp: stubResp{status: 403, body: `{"message":"Forbidden"}`}}
+	inst := &pluginInstance{PluginInstanceID: "pi-1", Alias: "my-plugin"}
+
+	_, err := setPluginInstanceState(context.Background(), c, inst, stateDisabled)
+	if err == nil || !strings.Contains(err.Error(), "not authorized to update") {
+		t.Fatalf("expected update forbidden mapping, got: %v", err)
+	}
+}
+
+func TestSetPluginInstanceState_TransportError(t *testing.T) {
+	c := &seqClient{patchResp: stubResp{err: errors.New("connection refused")}}
+	inst := &pluginInstance{PluginInstanceID: "pi-1"}
+
+	_, err := setPluginInstanceState(context.Background(), c, inst, stateDisabled)
+	if err == nil || !strings.Contains(err.Error(), "failed to update plugin instance state") {
+		t.Fatalf("expected wrapped transport error, got: %v", err)
 	}
 }

--- a/cmd/ui_plugins/ui_plugins.go
+++ b/cmd/ui_plugins/ui_plugins.go
@@ -42,6 +42,8 @@ func NewUIPluginsCommand() *cobra.Command {
 		newUploadCommand(),
 		newListCommand(),
 		newDeleteCommand(),
+		newDisableCommand(),
+		newEnableCommand(),
 		newValidateManifestCommand(),
 	)
 

--- a/cmd/ui_plugins/ui_plugins_test.go
+++ b/cmd/ui_plugins/ui_plugins_test.go
@@ -3,6 +3,8 @@ package ui_plugins
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNewUIPluginsCommandStructure(t *testing.T) {
@@ -16,9 +18,25 @@ func TestNewUIPluginsCommandStructure(t *testing.T) {
 		t.Fatal("expected ui-plugins command to be hidden")
 	}
 
-	if len(cmd.Commands()) != 9 {
-		t.Fatalf("expected 9 subcommands, got %d", len(cmd.Commands()))
+	if len(cmd.Commands()) != 11 {
+		t.Fatalf("expected 11 subcommands, got %d", len(cmd.Commands()))
 	}
+
+	for _, name := range []string{"disable", "enable"} {
+		if !hasSubcommand(cmd, name) {
+			t.Fatalf("expected %q subcommand to be registered", name)
+		}
+	}
+}
+
+// hasSubcommand reports whether cmd has a direct subcommand with the given name.
+func hasSubcommand(cmd *cobra.Command, name string) bool {
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 func TestUIPluginsGateDisabled(t *testing.T) {

--- a/cmd/ui_plugins/validate_manifest_test.go
+++ b/cmd/ui_plugins/validate_manifest_test.go
@@ -144,4 +144,3 @@ func writeManifestAtPath(t *testing.T, path string, content string) {
 		t.Fatalf("failed to write manifest fixture: %v", err)
 	}
 }
-


### PR DESCRIPTION
## Description
This PR adds the enable and disable commands to the ui-plugins command group

## How Has This Been Tested?
Unit tests added and passing. Manual testing as specified in CSTM-368
