### PR TITLE
CSTM-393: Fix Windows CI failures in ui-plugins by TempDir cleanup ordering

### DIFF
--- a/.github/workflows/prb_windows.yml
+++ b/.github/workflows/prb_windows.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, ui-plugins]
+    branches: [main]
 
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/prb_windows.yml
+++ b/.github/workflows/prb_windows.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, ui-plugins]
 
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/cmd/ui_plugins/init_test.go
+++ b/cmd/ui_plugins/init_test.go
@@ -458,8 +458,12 @@ func initTestChdir(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
 	workdir := t.TempDir()
+	// Restore the working directory after t.TempDir registers its cleanup so
+	// that, under t.Cleanup's LIFO ordering, we chdir out before TempDir's
+	// RemoveAll runs. Windows cannot remove a directory that is the process's
+	// current working directory.
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
 	if err := os.Chdir(workdir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}

--- a/internal/initialize/fetch_subtree_test.go
+++ b/internal/initialize/fetch_subtree_test.go
@@ -64,8 +64,12 @@ func chdirTemp(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
 	workdir := t.TempDir()
+	// Restore the working directory after t.TempDir registers its cleanup so
+	// that, under t.Cleanup's LIFO ordering, we chdir out before TempDir's
+	// RemoveAll runs. Windows cannot remove a directory that is the process's
+	// current working directory.
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
 	if err := os.Chdir(workdir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}


### PR DESCRIPTION
## Description
The new command group ui-plugins added tests that exercised the cleanup ordering exposing a windows specific bug. These changes fix the ordering issue.

## How Has This Been Tested?
The initial failure can be seen on the Test step in this run: https://github.com/sailpoint-oss/sailpoint-cli/actions/runs/31108795639/job/92876821553

Ran the Windows PRB against this branch and confirmed the tests ran and passed: https://github.com/sailpoint-oss/sailpoint-cli/actions/runs/31186292128/job/92891554954?pr=249

_Note, there's a later error related to connectors due to dependency drift: `@types/node` is an unpinned, transitive dependency, re-resolved to "latest" on every `npm install`. Past runs (whenever they happened) pulled an older `@types/node` that TS 4.9 could still parse. A recent `@types/node` added `ffi.d.ts` using newer syntax, and that's what breaks._
