### PR TITLE
CSTM-409: Adding updates to angular schema to add custom dev server headers based off of create/link response. Adding fallback as well for schema project name drift.

### DIFF
--- a/cmd/ui_plugins/atomic_write.go
+++ b/cmd/ui_plugins/atomic_write.go
@@ -1,0 +1,64 @@
+package ui_plugins
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic replaces path with data by writing a temp file in the same
+// directory and renaming it into place. When path already exists, the
+// replacement keeps the original permission bits; otherwise 0644 is used.
+func writeFileAtomic(path string, data []byte) error {
+	perm, err := filePermissions(path, 0644)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file for %s: %w", filepath.Base(path), err)
+	}
+
+	tmpPath := tmp.Name()
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("set permissions on temp file for %s: %w", filepath.Base(path), err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file for %s: %w", filepath.Base(path), err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file for %s: %w", filepath.Base(path), err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file for %s: %w", filepath.Base(path), err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace %s: %w", filepath.Base(path), err)
+	}
+
+	succeeded = true
+	return nil
+}
+
+func filePermissions(path string, defaultPerm os.FileMode) (os.FileMode, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultPerm, nil
+		}
+		return 0, fmt.Errorf("stat %s: %w", filepath.Base(path), err)
+	}
+	return info.Mode().Perm(), nil
+}

--- a/cmd/ui_plugins/atomic_write_test.go
+++ b/cmd/ui_plugins/atomic_write_test.go
@@ -1,0 +1,97 @@
+package ui_plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, angularManifestFileName)
+	original := []byte(`{"version":1}`)
+	replacement := []byte(`{"version":1,"updated":true}` + "\n")
+
+	if err := os.WriteFile(path, original, 0600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := writeFileAtomic(path, replacement); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != string(replacement) {
+		t.Fatalf("content = %q, want %q", got, replacement)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("mode = %o, want %o", info.Mode().Perm(), os.FileMode(0600))
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, ".*"+angularManifestFileName+".tmp-*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no leftover temp files, found: %v", matches)
+	}
+}
+
+func TestWriteFileAtomicCreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, angularManifestFileName)
+	data := []byte("{\n}\n")
+
+	if err := writeFileAtomic(path, data); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("content = %q, want %q", got, data)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if info.Mode().Perm() != 0644 {
+		t.Fatalf("mode = %o, want %o", info.Mode().Perm(), os.FileMode(0644))
+	}
+}
+
+func TestFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, angularManifestFileName)
+
+	perm, err := filePermissions(path, 0644)
+	if err != nil {
+		t.Fatalf("missing file: %v", err)
+	}
+	if perm != 0644 {
+		t.Fatalf("default perm = %o, want %o", perm, os.FileMode(0644))
+	}
+
+	if err := os.WriteFile(path, []byte("{}"), 0600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	perm, err = filePermissions(path, 0644)
+	if err != nil {
+		t.Fatalf("existing file: %v", err)
+	}
+	if perm != 0600 {
+		t.Fatalf("existing perm = %o, want %o", perm, os.FileMode(0600))
+	}
+}

--- a/cmd/ui_plugins/create.go
+++ b/cmd/ui_plugins/create.go
@@ -145,6 +145,9 @@ func runCreate(ctx context.Context, c client.Client, manifestPath string, out io
 		return mapUMSCreateError(resp.StatusCode, body, cfg.Manifest.Alias)
 	}
 
+	headers, _ := parseDevDocumentHeaders(body)
+	applyDevDocumentHeadersBestEffort(manifestPath, cfg.Manifest.Alias, headers, errOut)
+
 	if opts.jsonOutput {
 		_, _ = fmt.Fprintln(out, string(body))
 		return nil

--- a/cmd/ui_plugins/create.md
+++ b/cmd/ui_plugins/create.md
@@ -18,6 +18,16 @@ When both are supplied, each slot's `restrictToUsers` is the de-duplicated union
 
 `--dry-run` validates the manifest, applies any overrides, and prints the exact payload that would be sent — without creating the instance. It also performs a read-only alias availability check against the tenant when possible; an alias that is already taken or invalid is reported, while an inconclusive check (e.g. connectivity or access) is noted without failing.
 
+## Local dev document headers
+
+On a successful create (not `--dry-run`), when the backend returns `devDocumentHeaders`, the CLI writes the `Content-Security-Policy` and `Permissions-Policy` values into `./angular.json` at `projects.<alias>.architect.serve.options.headers` (creating the `headers` object if needed). Values are copied as returned by the backend, including an empty `Permissions-Policy` when present. Other `serve.options` keys (such as HTTPS settings) are preserved. `sp-ui-plugin.json` is not modified for dev headers.
+
+The Angular project patched is resolved from the manifest alias: the CLI looks for `projects.<alias>` first (matching the project name `init` sets during scaffolding). If that key is missing but `angular.json` defines exactly one project, that sole project is updated instead. If multiple projects are defined and none matches the alias, create still succeeds with a warning on stderr that `angular.json` could not be updated; local dev CSP may remain stale until you rename the project to match the alias or add the headers manually under the correct project.
+
+If `./angular.json` is missing (for example, a non-Angular workspace attached with `init --path`), a note is printed and create still succeeds. When headers change, a restart reminder is printed to stderr — restart `ng serve` / `npm start` before testing in ISC.
+
+Use `--json` to inspect the raw backend response, including `devDocumentHeaders`; header patching still runs as a side effect unless backend omits that field.
+
 ## Output
 
 On success a short confirmation with the new plugin instance ID and alias is printed. Use `--json` to print the raw UMS response instead.

--- a/cmd/ui_plugins/create_test.go
+++ b/cmd/ui_plugins/create_test.go
@@ -3,9 +3,11 @@ package ui_plugins
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -159,6 +161,92 @@ func TestRunCreate_JSONPassthrough(t *testing.T) {
 	if strings.Contains(out.String(), "Created plugin instance") {
 		t.Fatalf("--json output should not include the human summary, got: %s", out.String())
 	}
+}
+
+func TestRunCreate_AppliesDevDocumentHeaders(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, manifestFileName)
+	writeManifestAtPath(t, manifestPath, testManifestJSON)
+	writeAngularFixture(t, dir, "access-request-plugin", false)
+
+	respBody := `{"pluginInstanceId":"pi-123","alias":"access-request-plugin","devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `","Permissions-Policy":"` + samplePP + `"}}`
+	fc := &fakeClient{status: http.StatusCreated, body: respBody}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, manifestPath, &out, &errOut, stubCurrentUser, createConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "Restart ng serve") {
+		t.Fatalf("expected restart note on stderr, got: %s", errOut.String())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, angularManifestFileName))
+	if err != nil {
+		t.Fatalf("read angular.json: %v", err)
+	}
+	if !strings.Contains(string(raw), sampleCSP) {
+		t.Fatalf("angular.json missing CSP: %s", raw)
+	}
+}
+
+func TestRunCreate_SucceedsWhenDevDocumentHeadersPatchFails(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, manifestFileName)
+	writeManifestAtPath(t, manifestPath, testManifestJSON)
+	writeMultiProjectAngularFixture(t, dir)
+
+	respBody := `{"pluginInstanceId":"pi-123","alias":"access-request-plugin","devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `"}}`
+	fc := &fakeClient{status: http.StatusCreated, body: respBody}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, manifestPath, &out, &errOut, stubCurrentUser, createConfig{})
+	if err != nil {
+		t.Fatalf("create should succeed when header patching fails, got: %v", err)
+	}
+	if !strings.Contains(out.String(), "Created plugin instance pi-123") {
+		t.Fatalf("expected success output, got: %s", out.String())
+	}
+	if !strings.Contains(errOut.String(), "Warning: could not update angular.json dev server headers") {
+		t.Fatalf("expected header patch warning on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestRunCreate_AppliesEmptyPermissionsPolicy(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, manifestFileName)
+	writeManifestAtPath(t, manifestPath, testManifestJSON)
+	writeAngularFixture(t, dir, "access-request-plugin", false)
+
+	respBody := `{"pluginInstanceId":"pi-123","alias":"access-request-plugin","devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `","Permissions-Policy":""}}`
+	fc := &fakeClient{status: http.StatusCreated, body: respBody}
+	var out, errOut bytes.Buffer
+
+	err := runCreate(context.Background(), fc, manifestPath, &out, &errOut, stubCurrentUser, createConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(readFileBytes(t, filepath.Join(dir, angularManifestFileName)), &root); err != nil {
+		t.Fatalf("parse angular.json: %v", err)
+	}
+	headers := root["projects"].(map[string]any)["access-request-plugin"].(map[string]any)["architect"].(map[string]any)["serve"].(map[string]any)["options"].(map[string]any)["headers"].(map[string]any)
+	if headers[headerContentSecurityPolicy] != sampleCSP {
+		t.Fatalf("CSP = %v", headers[headerContentSecurityPolicy])
+	}
+	if headers[headerPermissionsPolicy] != "" {
+		t.Fatalf("Permissions-Policy = %v, want empty string", headers[headerPermissionsPolicy])
+	}
+}
+
+func readFileBytes(t *testing.T, path string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return raw
 }
 
 func TestRunCreate_ErrorMapping(t *testing.T) {

--- a/cmd/ui_plugins/dev_document_headers.go
+++ b/cmd/ui_plugins/dev_document_headers.go
@@ -1,0 +1,247 @@
+package ui_plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	headerContentSecurityPolicy = "Content-Security-Policy"
+	headerPermissionsPolicy     = "Permissions-Policy"
+	angularManifestFileName     = "angular.json"
+)
+
+// devDocumentHeaders holds the plugin-document headers the backend
+// returns ephemerally on create/link for local dev CSP parity with
+// CDN uploads. A set* flag records whether the backend included that
+// key so absent keys are not written to angular.json.
+type devDocumentHeaders struct {
+	contentSecurityPolicy string
+	permissionsPolicy     string
+	setCSP                bool
+	setPP                 bool
+}
+
+func (h devDocumentHeaders) present() bool {
+	return h.setCSP || h.setPP
+}
+
+// parseDevDocumentHeaders extracts devDocumentHeaders from a successful
+// backend create or link response body. The second return value reports
+// whether the backend returned at least one known header key.
+func parseDevDocumentHeaders(body []byte) (devDocumentHeaders, bool) {
+	var parsed struct {
+		DevDocumentHeaders map[string]string `json:"devDocumentHeaders"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return devDocumentHeaders{}, false
+	}
+	return headersFromMap(parsed.DevDocumentHeaders)
+}
+
+func headersFromMap(m map[string]string) (devDocumentHeaders, bool) {
+	if len(m) == 0 {
+		return devDocumentHeaders{}, false
+	}
+
+	var h devDocumentHeaders
+	if v, ok := m[headerContentSecurityPolicy]; ok {
+		h.contentSecurityPolicy = v
+		h.setCSP = true
+	}
+	if v, ok := m[headerPermissionsPolicy]; ok {
+		h.permissionsPolicy = v
+		h.setPP = true
+	}
+	if !h.present() {
+		return devDocumentHeaders{}, false
+	}
+	return h, true
+}
+
+// applyDevDocumentHeadersBestEffort runs applyDevDocumentHeaders after a successful
+// create or link API call. Patching failures are reported to errOut and do not
+// fail the command.
+func applyDevDocumentHeadersBestEffort(manifestPath, alias string, headers devDocumentHeaders, errOut io.Writer) {
+	if err := applyDevDocumentHeaders(manifestPath, alias, headers, errOut); err != nil {
+		_, _ = fmt.Fprintf(errOut, "Warning: could not update %s dev server headers: %v\n", angularManifestFileName, err)
+	}
+}
+
+// applyDevDocumentHeaders writes backend dev document headers into
+// the workspace angular.json when present. Missing angular.json or
+// empty headers are reported to errOut and treated as non-fatal.
+func applyDevDocumentHeaders(manifestPath, alias string, headers devDocumentHeaders, errOut io.Writer) error {
+	if !headers.present() {
+		_, _ = fmt.Fprintln(errOut, "Note: the backend did not return dev document headers; angular.json was not updated.")
+		return nil
+	}
+
+	workspaceDir := filepath.Dir(manifestPath)
+	if workspaceDir == "." {
+		var err error
+		workspaceDir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("cannot resolve workspace directory: %w", err)
+		}
+	}
+
+	angularPath := filepath.Join(workspaceDir, angularManifestFileName)
+	if _, err := os.Stat(angularPath); err != nil {
+		if os.IsNotExist(err) {
+			_, _ = fmt.Fprintf(errOut, "Note: %s not found; skipped writing dev document headers (non-Angular workspace).\n", angularManifestFileName)
+			return nil
+		}
+		return fmt.Errorf("cannot access %s: %w", angularManifestFileName, err)
+	}
+
+	raw, err := os.ReadFile(angularPath)
+	if err != nil {
+		return fmt.Errorf("unable to read %s: %w", angularManifestFileName, err)
+	}
+
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return fmt.Errorf("invalid %s: %w", angularManifestFileName, err)
+	}
+
+	projectsRaw, ok := root["projects"]
+	if !ok {
+		return fmt.Errorf("%s has no projects section", angularManifestFileName)
+	}
+
+	var projects map[string]json.RawMessage
+	if err := json.Unmarshal(projectsRaw, &projects); err != nil {
+		return fmt.Errorf("invalid projects in %s: %w", angularManifestFileName, err)
+	}
+
+	resolution, err := resolveAngularProjectKey(projects, alias)
+	if err != nil {
+		return err
+	}
+	projectKey := resolution.key
+
+	updated, changed, err := patchAngularDevServerHeaders(raw, projectKey, headers)
+	if err != nil {
+		return err
+	}
+
+	if !changed {
+		return nil
+	}
+
+	if err := writeFileAtomic(angularPath, updated); err != nil {
+		return fmt.Errorf("failed to write %s: %w", angularManifestFileName, err)
+	}
+
+	if resolution.usedSoleProjectFallback {
+		_, _ = fmt.Fprintf(errOut, "Note: manifest alias %q does not match the sole Angular project %q in %s; dev server headers were applied to that project anyway.\n", alias, projectKey, angularManifestFileName)
+	}
+
+	_, _ = fmt.Fprintln(errOut, "Updated angular.json dev server headers. Restart ng serve / npm start for the changes to take effect.")
+	return nil
+}
+
+type angularProjectResolution struct {
+	key                     string
+	usedSoleProjectFallback bool
+}
+
+// resolveAngularProjectKey picks the Angular project to patch: alias match first,
+// then the sole project when unambiguous.
+func resolveAngularProjectKey(projects map[string]json.RawMessage, alias string) (angularProjectResolution, error) {
+	if alias != "" {
+		if _, ok := projects[alias]; ok {
+			return angularProjectResolution{key: alias}, nil
+		}
+	}
+
+	switch len(projects) {
+	case 0:
+		return angularProjectResolution{}, fmt.Errorf("%s defines no Angular projects", angularManifestFileName)
+	case 1:
+		for name := range projects {
+			res := angularProjectResolution{key: name}
+			if alias != "" && name != alias {
+				res.usedSoleProjectFallback = true
+			}
+			return res, nil
+		}
+	default:
+		if alias != "" {
+			return angularProjectResolution{}, fmt.Errorf("manifest alias %q does not match any project in %s; specify a matching alias or use a single-project workspace", alias, angularManifestFileName)
+		}
+		return angularProjectResolution{}, fmt.Errorf("%s defines multiple projects; cannot choose which project to patch", angularManifestFileName)
+	}
+	return angularProjectResolution{}, fmt.Errorf("cannot resolve Angular project in %s", angularManifestFileName)
+}
+
+// patchAngularDevServerHeaders updates serve.options.headers for projectKey and
+// re-encodes the full angular.json document.
+func patchAngularDevServerHeaders(raw []byte, projectKey string, headers devDocumentHeaders) ([]byte, bool, error) {
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, false, fmt.Errorf("invalid %s: %w", angularManifestFileName, err)
+	}
+
+	projects, ok := root["projects"].(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("%s has no projects section", angularManifestFileName)
+	}
+
+	project, ok := projects[projectKey].(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("%s has no project %q", angularManifestFileName, projectKey)
+	}
+
+	architect, ok := project["architect"].(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("project %q in %s has no architect section", projectKey, angularManifestFileName)
+	}
+
+	serve, ok := architect["serve"].(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("project %q in %s has no architect.serve target", projectKey, angularManifestFileName)
+	}
+
+	options, ok := serve["options"].(map[string]any)
+	if !ok {
+		options = map[string]any{}
+		serve["options"] = options
+	}
+
+	headersObj, ok := options["headers"].(map[string]any)
+	if !ok {
+		headersObj = map[string]any{}
+		options["headers"] = headersObj
+	}
+
+	changed := false
+	if headers.setCSP {
+		cur, ok := headersObj[headerContentSecurityPolicy].(string)
+		if !ok || cur != headers.contentSecurityPolicy {
+			headersObj[headerContentSecurityPolicy] = headers.contentSecurityPolicy
+			changed = true
+		}
+	}
+	if headers.setPP {
+		cur, ok := headersObj[headerPermissionsPolicy].(string)
+		if !ok || cur != headers.permissionsPolicy {
+			headersObj[headerPermissionsPolicy] = headers.permissionsPolicy
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil, false, nil
+	}
+
+	updated, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to encode %s: %w", angularManifestFileName, err)
+	}
+	return append(updated, '\n'), true, nil
+}

--- a/cmd/ui_plugins/dev_document_headers_test.go
+++ b/cmd/ui_plugins/dev_document_headers_test.go
@@ -1,0 +1,366 @@
+package ui_plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleCSP = "default-src 'self'; connect-src 'self' https://tenant.api.cloud.sailpoint.com"
+const samplePP = "camera=(), microphone=()"
+
+func devHeaders(csp, pp string, setCSP, setPP bool) devDocumentHeaders {
+	return devDocumentHeaders{
+		contentSecurityPolicy: csp,
+		permissionsPolicy:     pp,
+		setCSP:                setCSP,
+		setPP:                 setPP,
+	}
+}
+
+func TestParseDevDocumentHeadersFromCreate(t *testing.T) {
+	body := `{"pluginInstanceId":"pi-1","alias":"acme","devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `","Permissions-Policy":"` + samplePP + `"}}`
+	got, ok := parseDevDocumentHeaders([]byte(body))
+	if !ok {
+		t.Fatal("expected headers to be present")
+	}
+	if got.contentSecurityPolicy != sampleCSP || !got.setCSP {
+		t.Fatalf("CSP = %q set=%v", got.contentSecurityPolicy, got.setCSP)
+	}
+	if got.permissionsPolicy != samplePP || !got.setPP {
+		t.Fatalf("PP = %q set=%v", got.permissionsPolicy, got.setPP)
+	}
+}
+
+func TestParseDevDocumentHeaders_EmptyPermissionsPolicyValue(t *testing.T) {
+	body := `{"devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `","Permissions-Policy":""}}`
+	got, ok := parseDevDocumentHeaders([]byte(body))
+	if !ok {
+		t.Fatal("expected headers to be present")
+	}
+	if !got.setCSP || got.contentSecurityPolicy != sampleCSP {
+		t.Fatalf("CSP not parsed: %+v", got)
+	}
+	if !got.setPP || got.permissionsPolicy != "" {
+		t.Fatalf("expected empty PP with setPP=true, got %+v", got)
+	}
+}
+
+func TestParseDevDocumentHeadersFromLink(t *testing.T) {
+	body := `{"devOverrides":{"devUrl":"https://localhost:4200"},"devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `"}}`
+	got, ok := parseDevDocumentHeaders([]byte(body))
+	if !ok {
+		t.Fatal("expected headers to be present")
+	}
+	if got.contentSecurityPolicy != sampleCSP || !got.setCSP {
+		t.Fatalf("CSP = %q set=%v", got.contentSecurityPolicy, got.setCSP)
+	}
+	if got.setPP {
+		t.Fatal("PP should not be set when absent from UMS")
+	}
+}
+
+func TestParseDevDocumentHeaders_MissingField(t *testing.T) {
+	if _, ok := parseDevDocumentHeaders([]byte(`{"pluginInstanceId":"pi-1"}`)); ok {
+		t.Fatal("expected missing field to report false")
+	}
+	if _, ok := parseDevDocumentHeaders([]byte(`{"devOverrides":{}}`)); ok {
+		t.Fatal("expected missing headers to report false")
+	}
+	if _, ok := parseDevDocumentHeaders([]byte(`{"devDocumentHeaders":{}}`)); ok {
+		t.Fatal("expected empty devDocumentHeaders object to report false")
+	}
+}
+
+func TestResolveAngularProjectKey(t *testing.T) {
+	projects := map[string]json.RawMessage{
+		"acme-plugin": json.RawMessage(`{}`),
+		"other":       json.RawMessage(`{}`),
+	}
+
+	res, err := resolveAngularProjectKey(projects, "acme-plugin")
+	if err != nil || res.key != "acme-plugin" || res.usedSoleProjectFallback {
+		t.Fatalf("alias match: res=%+v err=%v", res, err)
+	}
+
+	sole := map[string]json.RawMessage{"only": json.RawMessage(`{}`)}
+	res, err = resolveAngularProjectKey(sole, "missing-alias")
+	if err != nil || res.key != "only" || !res.usedSoleProjectFallback {
+		t.Fatalf("sole project: res=%+v err=%v", res, err)
+	}
+
+	if _, err := resolveAngularProjectKey(projects, "missing"); err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+}
+
+func TestApplyDevDocumentHeaders_SoleProjectFallbackNotice(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestAtPath(t, filepath.Join(dir, manifestFileName), testManifestJSON)
+	writeAngularFixture(t, dir, "legacy-project-name", false)
+
+	var errOut bytes.Buffer
+	headers := devHeaders(sampleCSP, samplePP, true, true)
+	if err := applyDevDocumentHeaders(filepath.Join(dir, manifestFileName), "access-request-plugin", headers, &errOut); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	msg := errOut.String()
+	if !strings.Contains(msg, `manifest alias "access-request-plugin" does not match the sole Angular project "legacy-project-name"`) {
+		t.Fatalf("expected sole-project fallback note, got: %s", msg)
+	}
+	if !strings.Contains(msg, "headers were applied to that project anyway") {
+		t.Fatalf("expected fallback confirmation, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Restart ng serve") {
+		t.Fatalf("expected restart note, got: %s", msg)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, angularManifestFileName))
+	if err != nil {
+		t.Fatalf("read angular.json: %v", err)
+	}
+	if !strings.Contains(string(raw), sampleCSP) {
+		t.Fatalf("expected headers on sole project, got: %s", raw)
+	}
+}
+
+func TestPatchAngularDevServerHeaders(t *testing.T) {
+	raw := []byte(`{
+  "projects": {
+    "acme-plugin": {
+      "architect": {
+        "serve": {
+          "options": {
+            "ssl": true
+          }
+        }
+      }
+    }
+  }
+}`)
+
+	updated, changed, err := patchAngularDevServerHeaders(raw, "acme-plugin", devHeaders(sampleCSP, samplePP, true, true))
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on first patch")
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(updated, &root); err != nil {
+		t.Fatalf("updated JSON invalid: %v", err)
+	}
+	projects := root["projects"].(map[string]any)
+	project := projects["acme-plugin"].(map[string]any)
+	serve := project["architect"].(map[string]any)["serve"].(map[string]any)
+	options := serve["options"].(map[string]any)
+	if options["ssl"] != true {
+		t.Fatal("ssl option should be preserved")
+	}
+	headers := options["headers"].(map[string]any)
+	if headers[headerContentSecurityPolicy] != sampleCSP {
+		t.Fatalf("CSP not written: %v", headers)
+	}
+	if headers[headerPermissionsPolicy] != samplePP {
+		t.Fatalf("PP not written: %v", headers)
+	}
+
+	_, changed, err = patchAngularDevServerHeaders(updated, "acme-plugin", devHeaders(sampleCSP, samplePP, true, true))
+	if err != nil {
+		t.Fatalf("second patch: %v", err)
+	}
+	if changed {
+		t.Fatal("expected changed=false when headers unchanged")
+	}
+}
+
+func TestPatchAngularDevServerHeaders_EmptyPermissionsPolicy(t *testing.T) {
+	raw := []byte(`{
+  "projects": {
+    "acme-plugin": {
+      "architect": {
+        "serve": {
+          "options": {
+            "headers": {}
+          }
+        }
+      }
+    }
+  }
+}`)
+
+	updated, changed, err := patchAngularDevServerHeaders(raw, "acme-plugin", devHeaders(sampleCSP, "", true, true))
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(updated, &root); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	headers := root["projects"].(map[string]any)["acme-plugin"].(map[string]any)["architect"].(map[string]any)["serve"].(map[string]any)["options"].(map[string]any)["headers"].(map[string]any)
+	if headers[headerContentSecurityPolicy] != sampleCSP {
+		t.Fatalf("CSP = %v", headers[headerContentSecurityPolicy])
+	}
+	pp, ok := headers[headerPermissionsPolicy].(string)
+	if !ok {
+		t.Fatalf("Permissions-Policy key missing: %v", headers)
+	}
+	if pp != "" {
+		t.Fatalf("Permissions-Policy = %q, want empty string", pp)
+	}
+}
+
+func TestPatchAngularDevServerHeaders_CSPOnlyLeavesPermissionsPolicyUntouched(t *testing.T) {
+	raw := []byte(`{
+  "projects": {
+    "acme-plugin": {
+      "architect": {
+        "serve": {
+          "options": {
+            "headers": {
+              "Permissions-Policy": "camera=()"
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+
+	updated, changed, err := patchAngularDevServerHeaders(raw, "acme-plugin", devHeaders(sampleCSP, "", true, false))
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected CSP change")
+	}
+
+	headers := jsonPath(t, updated, "projects", "acme-plugin", "architect", "serve", "options", "headers")
+	if headers[headerContentSecurityPolicy] != sampleCSP {
+		t.Fatalf("CSP = %v", headers[headerContentSecurityPolicy])
+	}
+	if headers[headerPermissionsPolicy] != "camera=()" {
+		t.Fatalf("existing PP should be preserved, got %v", headers[headerPermissionsPolicy])
+	}
+}
+
+func TestApplyDevDocumentHeaders_WritesAngularJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestAtPath(t, filepath.Join(dir, manifestFileName), testManifestJSON)
+	writeAngularFixture(t, dir, "access-request-plugin", false)
+
+	var errOut bytes.Buffer
+	headers := devHeaders(sampleCSP, samplePP, true, true)
+	if err := applyDevDocumentHeaders(filepath.Join(dir, manifestFileName), "access-request-plugin", headers, &errOut); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "Restart ng serve") {
+		t.Fatalf("expected restart note, got: %s", errOut.String())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, angularManifestFileName))
+	if err != nil {
+		t.Fatalf("read angular.json: %v", err)
+	}
+	if !strings.Contains(string(raw), sampleCSP) {
+		t.Fatalf("angular.json missing CSP: %s", raw)
+	}
+}
+
+func TestApplyDevDocumentHeaders_SkipsMissingAngularJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestAtPath(t, filepath.Join(dir, manifestFileName), testManifestJSON)
+
+	var errOut bytes.Buffer
+	err := applyDevDocumentHeaders(filepath.Join(dir, manifestFileName), "access-request-plugin", devHeaders(sampleCSP, "", true, false), &errOut)
+	if err != nil {
+		t.Fatalf("expected non-fatal skip, got: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "not found") {
+		t.Fatalf("expected skip note, got: %s", errOut.String())
+	}
+}
+
+func jsonPath(t *testing.T, raw []byte, keys ...string) map[string]any {
+	t.Helper()
+	var cur any
+	if err := json.Unmarshal(raw, &cur); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("expected object at %q", key)
+		}
+		cur = m[key]
+	}
+	m, ok := cur.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map at end of path")
+	}
+	return m
+}
+
+func writeAngularFixture(t *testing.T, dir, project string, withHeaders bool) {
+	t.Helper()
+	options := `"ssl": true`
+	if withHeaders {
+		options += `, "headers": {"Content-Security-Policy": "old-csp"}`
+	}
+	content := `{
+  "projects": {
+    "` + project + `": {
+      "architect": {
+        "serve": {
+          "options": {
+            ` + options + `
+          }
+        }
+      }
+    }
+  }
+}`
+	path := filepath.Join(dir, angularManifestFileName)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write angular.json: %v", err)
+	}
+}
+
+func writeMultiProjectAngularFixture(t *testing.T, dir string) {
+	t.Helper()
+	content := `{
+  "projects": {
+    "other-plugin": {
+      "architect": {
+        "serve": {
+          "options": {
+            "ssl": true
+          }
+        }
+      }
+    },
+    "another-plugin": {
+      "architect": {
+        "serve": {
+          "options": {
+            "ssl": true
+          }
+        }
+      }
+    }
+  }
+}`
+	path := filepath.Join(dir, angularManifestFileName)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write angular.json: %v", err)
+	}
+}

--- a/cmd/ui_plugins/init_scaffold.go
+++ b/cmd/ui_plugins/init_scaffold.go
@@ -123,7 +123,7 @@ func renameAngularProject(destDir, alias string) error {
 	// — robust across Angular versions and independent of angular.json layout.
 	content = strings.ReplaceAll(content, `"`+sentinelName+`:`, `"`+alias+`:`)
 
-	return os.WriteFile(path, []byte(content), 0644)
+	return writeFileAtomic(path, []byte(content))
 }
 
 func setPackageName(destDir, alias string) error {

--- a/cmd/ui_plugins/link.go
+++ b/cmd/ui_plugins/link.go
@@ -85,12 +85,19 @@ func link(ctx context.Context, c client.Client, manifestPath string, flagPort in
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		// The response body is read only to explain a failure. The success
-		// path intentionally ignores it so this command does not depend on
-		// the link endpoint's response shape.
+		// The response body is read only to explain a failure. On success it
+		// carries devDocumentHeaders for angular.json patching.
 		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unable to create link: %s", umsErrorMessage(respBody))
 	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read link response: %w", err)
+	}
+
+	headers, _ := parseDevDocumentHeaders(respBody)
+	applyDevDocumentHeadersBestEffort(manifestPath, cfg.Manifest.Alias, headers, errOut)
 
 	viewURL := pluginViewURL(tenantUrl, instance.PluginInstanceID)
 	if viewURL == "" {

--- a/cmd/ui_plugins/link.md
+++ b/cmd/ui_plugins/link.md
@@ -19,6 +19,14 @@ On success the command prints a single fully qualified developer URL to stdout, 
 
 The URL is the only thing written to stdout (informational messages go to stderr) so it can be piped or picked up by your terminal's link detection without truncation or masking.
 
+## Local dev document headers
+
+On success, when the backend returns `devDocumentHeaders`, the CLI refreshes `Content-Security-Policy` and `Permissions-Policy` in `./angular.json` at `projects.<alias>.architect.serve.options.headers`. Only keys present in the backend response are updated; values are copied as-is, including an empty `Permissions-Policy` when the backend sends one. Other `serve.options` keys are preserved.
+
+The Angular project patched is resolved from the manifest alias: the CLI looks for `projects.<alias>` first (matching the project name `init` sets during scaffolding). If that key is missing but `angular.json` defines exactly one project, that sole project is updated instead. If multiple projects are defined and none matches the alias, link still succeeds and the developer URL is still printed to stdout, but header patching is skipped with a warning on stderr that `angular.json` could not be updated; local dev CSP may remain stale until you rename the project to match the alias or add the headers manually under the correct project.
+
+If `./angular.json` is missing, a note is printed and link still succeeds. When headers change, a restart reminder is printed to stderr — restart `ng serve` / `npm start` if the dev server was already running.
+
 ## Output
 
 The developer URL is printed to stdout; a short confirmation of the linked port is printed to stderr. Backend failures are surfaced with actionable detail.

--- a/cmd/ui_plugins/link_test.go
+++ b/cmd/ui_plugins/link_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -150,6 +152,72 @@ func TestLink_SuccessWithFlagPort(t *testing.T) {
 	}
 	if strings.Contains(errOut.String(), "defaulting to port") {
 		t.Fatalf("did not expect a defaulting notice when --port is set, got: %s", errOut.String())
+	}
+}
+
+func TestLink_AppliesDevDocumentHeaders(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, manifestFileName)
+	writeManifestAtPath(t, manifestPath, testManifestJSON)
+	writeAngularFixture(t, dir, "access-request-plugin", true)
+
+	linkBody := `{"devOverrides":{"devUrl":"https://localhost:4300"},"devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `"}}`
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   linkResolvedBody,
+		status:    http.StatusOK,
+		body:      linkBody,
+	}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, manifestPath, 4300, true, &out, &errOut)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "Restart ng serve") {
+		t.Fatalf("expected restart note, got: %s", errOut.String())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, angularManifestFileName))
+	if err != nil {
+		t.Fatalf("read angular.json: %v", err)
+	}
+	if !strings.Contains(string(raw), sampleCSP) {
+		t.Fatalf("angular.json missing updated CSP: %s", raw)
+	}
+	if strings.Contains(string(raw), "old-csp") {
+		t.Fatalf("angular.json should replace prior CSP: %s", raw)
+	}
+}
+
+func TestLink_PrintsDeveloperURLWhenDevDocumentHeadersPatchFails(t *testing.T) {
+	withTenantURL(t, "https://tenant.example.com")
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, manifestFileName)
+	writeManifestAtPath(t, manifestPath, testManifestJSON)
+	writeMultiProjectAngularFixture(t, dir)
+
+	linkBody := `{"devOverrides":{"devUrl":"https://localhost:4300"},"devDocumentHeaders":{"Content-Security-Policy":"` + sampleCSP + `"}}`
+	fc := &fakeClient{
+		getStatus: http.StatusOK,
+		getBody:   linkResolvedBody,
+		status:    http.StatusOK,
+		body:      linkBody,
+	}
+	var out, errOut bytes.Buffer
+
+	err := link(context.Background(), fc, manifestPath, 4300, true, &out, &errOut)
+	if err != nil {
+		t.Fatalf("link should succeed when header patching fails, got: %v", err)
+	}
+
+	wantDevURL := "https://tenant.example.com/ui/plugin/pi-123?spPluginDev=access-request-plugin"
+	if got := strings.TrimSpace(out.String()); got != wantDevURL {
+		t.Fatalf("stdout = %q, want exactly %q", got, wantDevURL)
+	}
+	if !strings.Contains(errOut.String(), "Warning: could not update angular.json dev server headers") {
+		t.Fatalf("expected header patch warning on stderr, got: %s", errOut.String())
 	}
 }
 


### PR DESCRIPTION
## Description
This PR adds header injection for the dev server to give 1:1 parity with deployed plugin code. The CLI intercepts the responses from `create` and `link` and updates angular.json schema to add the headers. Fallback has been added as well for angular.json schema drift from plugin alias (unlikely but good to have some kind of graceful fallback). Updated docs including fallback.

## How Has This Been Tested?
Unit tests, and steps in the manual verify ticket: CSTM-412
