### PR TITLE
CSTM-416: Temp commit to run windows prb on branches targeting ui-plugins

### DIFF
--- a/.github/workflows/prb_windows.yml
+++ b/.github/workflows/prb_windows.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, ui-plugins]
+    branches: [main]
 
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/prb_windows.yml
+++ b/.github/workflows/prb_windows.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, ui-plugins]
 
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/cmd/connector/static/connector/package.json
+++ b/cmd/connector/static/connector/package.json
@@ -24,6 +24,7 @@
     "prettier": "^2.3.2",
     "shx": "^0.3.3",
     "ts-jest": "^27.0.5",
+    "@types/node": "^18",
     "typescript": "^4.9.5",
     "cross-env": "7.0.3"
   },

--- a/cmd/connector/static/customizer/package.json
+++ b/cmd/connector/static/customizer/package.json
@@ -24,6 +24,7 @@
     "prettier": "^2.3.2",
     "shx": "^0.3.3",
     "ts-jest": "^27.0.5",
+    "@types/node": "^18",
     "typescript": "4.9.3",
     "cross-env": "7.0.3"
   },

--- a/cmd/ui_plugins/atomic_write_test.go
+++ b/cmd/ui_plugins/atomic_write_test.go
@@ -3,6 +3,7 @@ package ui_plugins
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -32,7 +33,9 @@ func TestWriteFileAtomic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat file: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	// Windows has no Unix permission model; Mode().Perm() only reflects the
+	// read-only bit, so exact-mode assertions cannot hold there.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Fatalf("mode = %o, want %o", info.Mode().Perm(), os.FileMode(0600))
 	}
 
@@ -66,7 +69,9 @@ func TestWriteFileAtomicCreatesNewFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat file: %v", err)
 	}
-	if info.Mode().Perm() != 0644 {
+	// Windows has no Unix permission model; Mode().Perm() only reflects the
+	// read-only bit, so exact-mode assertions cannot hold there.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0644 {
 		t.Fatalf("mode = %o, want %o", info.Mode().Perm(), os.FileMode(0644))
 	}
 }
@@ -91,7 +96,9 @@ func TestFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("existing file: %v", err)
 	}
-	if perm != 0600 {
+	// Windows has no Unix permission model; Mode().Perm() only reflects the
+	// read-only bit, so exact-mode assertions cannot hold there.
+	if runtime.GOOS != "windows" && perm != 0600 {
 		t.Fatalf("existing perm = %o, want %o", perm, os.FileMode(0600))
 	}
 }


### PR DESCRIPTION
## Description
This fixes an issue with the tests running on Windows to ensure that the file permissions check does not look for unix permissions.

Note: this branch also cherry-picks the changes from commit https://github.com/sailpoint-oss/sailpoint-cli/commit/e049366e77585ed056c3d6a3247b20465ad9b14f to ensure the windows PRB cleanup works as expected.

## How Has This Been Tested?
Temporarily ran the windows PRB against this branch and confirmed the Windows tests passed: ﻿﻿https://github.com/sailpoint-oss/sailpoint-cli/actions/runs/32274184525/job/96137551393
